### PR TITLE
Method → application → architecture organization + hybrid trainer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ Spyx has two tiers, and agents should respect the boundary when advising users:
 - **`spyx.experimental`** — research-stage building blocks whose **API may change
   without a deprecation cycle**: `PSU_LIF`, `ResonateFire`, `raven` (RavenRSM +
   SpikingSlotMemory), `compress` (packed-bit activations), `stochastic` (SPSN,
-  stochastic-associative neurons). Always import these from `spyx.experimental`
+  stochastic-associative neurons), `hybrid` (surrogate + orthogonal-ES error
+  correction), `zoo` (runnable recipes by application × method × architecture).
+  Always import these from `spyx.experimental`
   (e.g. `from spyx.experimental import PSU_LIF, RavenRSM`), never from a top-level
   module, so usage signals the stability contract. `PSU_LIF`/`ResonateFire` are
   physically defined in `nn`/`phasor` for code locality but are *surfaced* here.
@@ -55,7 +57,9 @@ spyx/
 │   │   ├── __init__.py #   PSU_LIF, ResonateFire (re-exported), + the modules:
 │   │   ├── raven.py    #   RavenRSM routing-slot memory + SpikingSlotMemory
 │   │   ├── compress.py #   bit-packed activation storage for BPTT memory
-│   │   └── stochastic.py #  SPSN, StochasticAssociative*, sigmoid_bernoulli
+│   │   ├── stochastic.py #  SPSN, StochasticAssociative*, sigmoid_bernoulli
+│   │   ├── hybrid.py   #   0+1 trainer: surrogate grad + orthogonal-ES correction
+│   │   └── zoo/        #   reference recipes (control/classification/language)
 │   └── _version.py     # Version information
 ├── tests/              # Test suite (conftest.py pins JAX to CPU + seeds fixtures)
 ├── docs/               # MkDocs docs, organized by Diátaxis
@@ -161,6 +165,18 @@ section above for the contract):
 - `compress` — `packed_spike_dense` (a `custom_vjp` matmul that stores its backward
   residual bit-packed for memory-efficient BPTT) + `pack_spikes`/`unpack_spikes`.
 - `stochastic` — `SPSN`, `StochasticAssociativeLIF`/`CuBaLIF`, `sigmoid_bernoulli`.
+- `hybrid` — the 0+1 trainer. `hybrid_gradient(model, loss_surrogate, loss_true,
+  key, ...)` returns a corrected gradient: the surrogate gradient plus an
+  antithetic-NES estimate of the true (hard-spike) loss gradient, projected
+  orthogonal to the surrogate (the complement of Guided-ES). Also
+  `make_hybrid_train_step`, `es_gradient`, `hybrid_diagnostics`. See
+  `research/new/hybrid_evo_surrogate/` for the three-arm study (honest result:
+  needs a small self-normalising λ to beat the surrogate).
+- `zoo` — runnable reference recipes keyed by application and tagged by training
+  method × architecture. `REGISTRY`/`list_recipes`/`get`; each recipe exposes
+  `build`, `synthetic_batch`, `demo` on synthetic data: `control-lif-es`
+  (evolutionary / LIF-MLP), `classification-rsnn` (surrogate / RSNN),
+  `language-s5` (gradient / S5).
 
 ### `quant.py` - Quantization (optional)
 Thin SNN-aware wrapper around Google's `qwix` library:

--- a/docs/explanation/choosing-an-approach.md
+++ b/docs/explanation/choosing-an-approach.md
@@ -1,0 +1,89 @@
+# Choosing an approach
+
+You have a task, a dataset, and a deadline. This page turns the
+[training-methods spine](training-methods.md) into a decision: given **what you
+are building** (the application) and **how you want to represent it** (the
+architecture), which **training method** should you reach for, and where is the
+Spyx entry point?
+
+Read it as two lookup tables plus a short flow at the end. The methods are the
+five from [Training methods](training-methods.md); skim that page first if a row
+name is unfamiliar.
+
+## Matrix A — method × application
+
+Rows are training methods; columns are the three application shapes Spyx targets.
+Each cell says how well the pairing **fits** and *why*.
+
+| Method | Control / RL | Classification | Language modelling |
+|---|---|---|---|
+| **Evolutionary** (0th) | **Strong.** No gradient through the environment needed; short episodes, small nets, population `vmap`s well. The canonical fit — see [`cartpole_evo`](../examples/neuroevolution/cartpole_evo.ipynb). | **Niche.** Works on tiny models or when optimising the exact hard-spike objective, but sample cost makes it uncompetitive at scale. | **Poor.** Parameter counts and sequence lengths blow up ES variance; not a serious option. |
+| **Surrogate gradient** (1st) | **OK.** Works when the environment is differentiable or you train a policy by BPTT, but for black-box control ES is usually simpler. | **Strong — the default.** Labelled data + differentiable surrogate + Optax scaling. This is the workhorse path ([SurrogateGradientTutorial](../examples/surrogate_gradient/SurrogateGradientTutorial.ipynb)). | **Strong.** BPTT through long sequences is exactly what surrogate + SSM/phasor backbones are for; the scalable choice. |
+| **Conversion & QAT** (transfer) | **Rare.** Little to convert *from* in RL; skip unless you already have a trained policy to quantize. | **Strong.** Convert a trained ANN classifier to a rate-coded SNN, or QAT-fine-tune an fp32 SNN for int8/ternary deployment. | **Emerging.** Quantized sequence models (e.g. Q-S5) are viable; conversion is harder because temporal structure matters. |
+| **Local / bio-inspired** | **Roadmap.** Online RL is a natural fit for e-prop, but not yet a Spyx API ([#28](https://github.com/kmheckel/spyx/issues/28)). | **Roadmap.** Feedback alignment / synthetic grads apply, but unshipped ([#27](https://github.com/kmheckel/spyx/issues/27)). | **Roadmap.** Long-context memory-bounded training is the motivation; aspirational today. |
+| **0+1 hybrid** | **Good.** When you optimise a hard-spike control loss and want a cheap descent bulk plus an unbiased hard-objective correction. | **Good when 1st-order plateaus.** Use it to close the surrogate-bias gap on the hard-spike classifier, not as a first move. | **Situational.** Extra hard-forward passes cost more at long `T`; reserve for when surrogate bias visibly hurts. |
+
+**How to read a cell.** "Strong" = the method's information order matches the
+task's structure, so it is the efficient choice. "Roadmap" = the fit is real but
+the Spyx API does not exist yet — track the linked issue. When two cells are both
+"Strong", let the architecture (Matrix B) and your compute budget break the tie.
+
+## Matrix B — method × architecture
+
+Columns are the four Spyx backbones you might build with. Each cell says which
+methods **pair well** with that architecture and why.
+
+| Architecture | Pairs well with | Notes |
+|---|---|---|
+| **LIF / RSNN** — [`spyx.nn`](../reference/nn.md) | Surrogate gradient (default); Evolutionary (small nets / control); Conversion & QAT | The reference case: hard spikes make surrogate gradients *necessary* and make weight-only quantization *lossless* ([`spiking_feedforward_rules`](../reference/quant.md)). ES trains the same `nnx.Module` gradient-free. |
+| **SSM / S5** — [`spyx.ssm`](../reference/ssm.md) | Surrogate gradient (long sequences); QAT (Q-S5); Transfer *into* spiking | Linear associative-scan recurrence is fully differentiable and BPTT-friendly, so 1st-order shines. Diagonal state quantizes well; [`ssm_to_spiking_transfer`](https://github.com/kmheckel/spyx/tree/main/research/new/ssm_to_spiking_transfer) studies moving SSM dynamics into spiking neurons. |
+| **Phasor** — [`spyx.phasor`](../reference/phasor.md) | Surrogate gradient (complex/oscillatory dynamics) | Complex poles are stored as **real** params, so a stock `optax` + `jax.grad` loop over a real loss trains them without Wirtinger surprises. ES also applies; QAT on complex weights is unexplored. |
+| **Slot-memory / Raven** — [`spyx.experimental.raven`](../reference/experimental.md) | Surrogate gradient (recall tasks); (roadmap) local rules for online memory | Routing-slot memory (`RavenRSM` + spiking sibling) is trained by BPTT for high-recall sequence tasks — see [`raven_sparse_memory_recall`](https://github.com/kmheckel/spyx/tree/main/research/new/raven_sparse_memory_recall). Being experimental, its API can move. |
+
+**The through-line.** Surrogate gradient ([`spyx.axn`](../reference/axn.md) +
+[`spyx.optimize`](../reference/optimize.md)) pairs with *every* architecture — it
+is the common substrate. The other methods are specialisations: ES when there is
+no usable gradient, conversion/QAT when you inherit or must shrink a model, local
+rules when locality is a hard constraint (not yet shipped), and the hybrid when
+the surrogate's bias on the hard-spike loss is the thing costing you accuracy.
+
+## Start here
+
+A four-step flow from a cold start:
+
+1. **Name the task → pick the application.** Is it *control/RL*, *classification*,
+   or *language modelling*? That is the column in Matrix A.
+2. **Pick the architecture** for how you want to represent it — a
+   [LIF/RSNN](../reference/nn.md) for event-driven and neuromorphic-bound work, an
+   [SSM/S5](../reference/ssm.md) for long differentiable sequences, a
+   [phasor](../reference/phasor.md) net for oscillatory/frequency-selective
+   dynamics, or [Raven slot-memory](../reference/experimental.md) for
+   high-recall memory tasks. That is the row in Matrix B.
+3. **Pick the method** where both matrices agree:
+    - Differentiable forward + labelled data → **surrogate gradient** (start with
+      [`spyx.optimize.fit`](../reference/optimize.md) and a
+      [`spyx.axn`](../reference/axn.md) surrogate). This is the right first move
+      for the large majority of tasks.
+    - Non-differentiable forward, or you must optimise the exact hard-spike / reward
+      objective, or it's small-net control → **evolutionary** (`evosax` +
+      `spyx.experimental.zoo`; [cartpole notebook](../examples/neuroevolution/cartpole_evo.ipynb)).
+    - You already have a trained model, or you're hitting an efficiency/energy
+      budget → **conversion & QAT** ([`spyx.quant`](../reference/quant.md);
+      [QAT notebook](../examples/quantization/qat_intro.ipynb)).
+    - Surrogate-gradient training *works but plateaus below the hard-spike model
+      you deploy* → add the **0+1 hybrid** correction (`spyx.experimental.hybrid`).
+    - You need *online / on-chip* local learning → it's **roadmap**
+      ([#27](https://github.com/kmheckel/spyx/issues/27),
+      [#28](https://github.com/kmheckel/spyx/issues/28)); use surrogate-gradient
+      BPTT plus [`spyx.experimental.compress`](../reference/experimental.md) for
+      the memory pressure in the meantime.
+4. **Measure, then iterate.** Confirm the choice with real numbers —
+   [`spyx.bench`](../reference/bench.md) for latency / throughput / spike-rate
+   energy proxy (see the [benchmarking how-to](../how-to/benchmarking.md)) — and
+   only reach for a heavier method (ES samples, a hybrid correction) once the
+   default has actually under-delivered.
+
+When in doubt: **start with a surrogate-gradient LIF network and
+[`spyx.optimize.fit`](../reference/optimize.md)**, measure, and specialise from
+there. Every other method on this page is a considered deviation from that
+baseline, not a replacement for trying it first.

--- a/docs/explanation/surrogate-gradients-and-gaussian-smoothing.md
+++ b/docs/explanation/surrogate-gradients-and-gaussian-smoothing.md
@@ -1,0 +1,220 @@
+# Surrogate gradients and Gaussian smoothing: two views of one mollification
+
+**Thesis.** The surrogate-gradient trick that makes spiking networks trainable
+and the Gaussian-smoothing trick that makes evolution strategies (ES) work are
+the *same operation* — convolving a Heaviside step with a bell-shaped kernel and
+differentiating the result — applied at two different levels of the computational
+graph. Surrogate gradients smooth **each neuron's spike in activation space**; ES
+smooths **the whole loss in parameter space**. Seeing them as one thing explains
+why the surrogate's *shape* barely matters, tells you exactly what its free
+parameter means, and grounds the hybrid trainer in
+[`spyx.experimental.hybrid`](../reference/experimental.md).
+
+This page is conceptual (Diátaxis *explanation*). For the taxonomy of training
+methods see [Training methods](training-methods.md); for the hybrid that exploits
+this connection see the [hybrid module](../reference/experimental.md).
+
+---
+
+## Leg 1 — ES computes the gradient of a Gaussian-smoothed loss
+
+Given any loss $L(\theta)$, define its **Gaussian-smoothed** version by convolving
+with an isotropic Gaussian of width $\sigma$:
+
+$$
+L_\sigma(\theta) \;=\; \mathbb{E}_{\varepsilon\sim\mathcal N(0,I)}\big[L(\theta+\sigma\varepsilon)\big]
+\;=\; (L * \varphi_\sigma)(\theta).
+$$
+
+$L_\sigma$ is smooth **even when $L$ is discontinuous**, and $L_\sigma \to L$ as
+$\sigma \to 0$ (a mollifier). Its gradient obeys the score-function / Stein
+identity
+
+$$
+\nabla L_\sigma(\theta)
+= \tfrac1\sigma\,\mathbb{E}\big[L(\theta+\sigma\varepsilon)\,\varepsilon\big]
+= \mathbb{E}\!\left[\frac{L(\theta+\sigma\varepsilon)-L(\theta-\sigma\varepsilon)}{2\sigma}\,\varepsilon\right],
+$$
+
+and the right-hand Monte-Carlo estimator is precisely **antithetic evolution
+strategies** (the estimator in `spyx.experimental.hybrid.es_gradient`). So ES is
+not a heuristic: it is an unbiased estimate of the gradient of the
+Gaussian-smoothed loss. This is the Nesterov–Spokoiny / Salimans view of ES.
+
+## Leg 2 — smoothing the Heaviside spike *is* a sigmoid, and its derivative *is* the surrogate
+
+Now do the same convolution one level down, at a single neuron. Let $v = u-\vartheta$
+be membrane potential minus threshold, so the spike is $s = H(v)$ with $H$ the
+Heaviside step. Convolve $H$ with a noise kernel $k$ of scale $\sigma$:
+
+$$
+H_\sigma(v) \;=\; \mathbb{E}_{\eta\sim k_\sigma}\big[H(v+\eta)\big]
+\;=\; \Pr\!\big[\eta > -v\big] \;=\; F_{k_\sigma}(v),
+$$
+
+the **CDF of the noise** — an S-curve, i.e. a *sigmoid*. Its derivative is the
+noise **density**:
+
+$$
+H_\sigma'(v) \;=\; k_\sigma(v),
+$$
+
+a bump centred at the threshold. This is exactly the surrogate-gradient recipe:
+the forward pass keeps the hard step $H(v)$, the backward pass multiplies by a
+bump $k_\sigma(v)$. **Every named surrogate is the density of a noise
+distribution, and the "smooth spike" it implies is that noise's CDF.** In the
+stochastic-neuron reading this kernel is the *escape-noise* firing-probability
+function: $\Pr[\text{spike}] = F_{k_\sigma}(v)$.
+
+### The `spyx.axn` surrogates, read as smoothing kernels
+
+Each factory in [`spyx.axn`](../reference/axn.md) exposes a backward bump
+$g(x)$. Identifying $g$ with a noise density $k_\sigma$ names the implicit
+smoothing kernel; the sharpness $k$ is an **inverse smoothing width**,
+$k \sim 1/\sigma$.
+
+| `spyx.axn` factory | surrogate derivative $g(x)$ | implied noise kernel $k_\sigma$ | smoothed spike (CDF) |
+| --- | --- | --- | --- |
+| `tanh(k)` | $\operatorname{sech}^2(kx)$ | logistic / hyperbolic-secant | logistic sigmoid $\tfrac12(1+\tanh kx)$ |
+| `arctan(k)` | $\dfrac{1}{\pi\,(1+(k\pi x)^2)}$ | Cauchy / Lorentzian (heavy-tailed) | $\tfrac1\pi\arctan(k\pi x)+\tfrac12$ |
+| `superspike(k)` | $\dfrac{1}{(1+k\lvert x\rvert)^2}$ | fast-sigmoid (Zenke–Ganguli) | fast sigmoid $\tfrac12\!\left(1+\tfrac{kx}{1+k\lvert x\rvert}\right)$ |
+| `triangular(k)` | $\max(0,\,1-\lvert kx\rvert)$ | triangular (sum of two uniforms) | piecewise-quadratic S-curve |
+| `boxcar(w,h)` | $h\,\mathbb{1}[\lvert x\rvert\le w/2]$ | uniform on $[-w/2,\,w/2]$ | hard-sigmoid (clipped ramp) |
+| `heaviside` / STE | $1$ (identity backward) | improper uniform on $\mathbb R$ | degenerate: infinite-width smoothing |
+| *(Gaussian)* | $\propto e^{-x^2/2\sigma^2}$ | Gaussian | probit $\Phi(x/\sigma)$ |
+
+The straight-through estimator is the $\sigma\to\infty$ corner: smooth so hard
+that the density is flat and the backward pass is the identity. The Gaussian row
+is the one that makes Leg 1 and Leg 2 *literally the same kernel*.
+
+---
+
+## The bridge — and the asymmetry that matters
+
+Both methods defeat the same obstacle (the derivative of $H$ is zero almost
+everywhere, or a Dirac at the threshold) by the same means (convolve with a
+kernel, differentiate the smooth result). They differ in **where** the noise is
+injected and **how** the gradient is taken:
+
+|  | Surrogate gradient | Evolution strategies |
+| --- | --- | --- |
+| noise injected into | each neuron's pre-activation $v$ (**activation space**) | parameters $\theta$ (**parameter space**) |
+| kernel | `spyx.axn` bump ($\operatorname{sech}^2$, Cauchy, box, …) | Gaussian $\varphi_\sigma$ |
+| gradient computed by | analytic backprop through the smoothed step | Monte-Carlo sampling (score-function) |
+| forward/backward | **inconsistent** — hard forward, soft backward | **consistent** — perturbs the actual forward |
+| cost / variance | one pass, deterministic, cheap | $2K$ passes, unbiased, high-variance |
+
+There is one asymmetry worth stating sharply, because it is the crux. **ES is the
+gradient of an honest, global smoothed loss** $L_\sigma(\theta)$. The
+multi-layer surrogate gradient, by contrast, is *not* the gradient of any global
+loss: it coincides with a derivative of the escape-noise firing probability only
+**per neuron**, and composing these per-neuron smoothings through the network does
+not integrate back to a single scalar objective (Gygax & Zenke, 2025). The
+surrogate is a *locally-mollified pseudo-gradient*; ES is a *globally-mollified
+true gradient*.
+
+They agree only in a degenerate case: if the map $\theta \mapsto v$ were affine
+and the kernels were matched, parameter-space smoothing would push forward exactly
+to activation-space smoothing and the two gradients would coincide. Real networks
+are deep and nonlinear, so they diverge — **and that divergence is precisely the
+surrogate's bias.**
+
+### Why this grounds the Spyx hybrid trainer
+
+The [hybrid method](training-methods.md) reads directly off the
+asymmetry. With both quantities estimating (aspects of) the *same* smoothed
+landscape:
+
+- $g_s$ — the surrogate gradient — is the cheap, deterministic, *locally*-smoothed
+  pseudo-gradient (biased: it is not a true $\nabla L_\sigma$).
+- $g_{es}$ — the ES estimate — is the noisy but *globally*-smoothed true gradient
+  $\nabla L_\sigma$.
+- $g_{\text{orth}} = g_{es} - \langle g_{es}, \hat g_s\rangle \hat g_s$ — the ES
+  estimate with its surrogate-aligned part removed — is an estimate of exactly the
+  component of the true smoothed gradient that the local surrogate *cannot see*:
+  its bias.
+
+So "surrogate bulk direction + orthogonal ES correction" is not an arbitrary
+blend — it is "cheap local mollification, corrected in the subspace where local
+and global mollification disagree." (The empirical caveat from the study stands:
+the correction is high-variance and only pays off when the surrogate's bias is
+large; see the [hybrid study](https://github.com/kmheckel/spyx/tree/main/research/new/hybrid_evo_surrogate).)
+
+---
+
+## What the unified view predicts
+
+- **Shape-robustness.** Any normalized bump is a valid mollifier, and to leading
+  order all mollifiers of the same width give the same smoothed landscape. So the
+  *shape* of the surrogate should be nearly irrelevant and only its *width* should
+  matter — which is exactly the striking empirical finding of Zenke & Vogels
+  (2021). The smoothing view predicts it rather than merely observing it.
+- **The free parameter is a resolution knob.** The sharpness $k$ in `spyx.axn`
+  is an inverse smoothing scale $k\sim 1/\sigma$: too sharp ($k\to\infty$) removes
+  the smoothing and reinstates the dead Heaviside derivative (vanishing-gradient
+  regions); too broad over-smooths and biases. Same bias/resolution trade-off as
+  choosing $\sigma$ in ES.
+- **Annealing = graduated non-convexity.** Scheduling the surrogate from broad to
+  sharp is continuation/graduated-non-convexity on the mollified loss — a
+  principled reason to anneal $k$ (equivalently $\sigma$) during training.
+- **The exact-coincidence object already ships.** In a *stochastic* SNN where the
+  spike is literally $\mathrm{Bernoulli}(F(v))$, the expected output is the sigmoid
+  $F(v)$ and the surrogate gradient becomes the **exact** gradient of the expected
+  loss — no approximation. That is
+  [`spyx.experimental.stochastic.sigmoid_bernoulli`](../reference/experimental.md)
+  / `SPSN`: the object where Leg 1 and Leg 2 collapse into one and the surrogate
+  stops being a surrogate.
+
+---
+
+## Honest placement in the literature
+
+!!! note "What is established vs. what this page adds"
+    **Both legs are known results.** ES as the gradient of a Gaussian-smoothed
+    loss is standard (Nesterov & Spokoiny 2017; Salimans et al. 2017). The
+    surrogate-derivative-as-smoothed/stochastic-firing-function is established, and
+    the subtle point that multi-layer surrogate gradients are *not* the gradient of
+    any surrogate loss is due to Gygax & Zenke (2025). Framing surrogate gradients
+    as adaptive smoothing also appears in Wang et al. (2023).
+
+    **What this note draws together** — and what we have not seen stated explicitly
+    in the SNN literature — is the *bridge*: that the surrogate-derivative bump and
+    the ES perturbation density are the **same mollification kernel** acting at two
+    different levels (per-neuron activation space vs. global parameter space), that
+    this makes surrogate-GD and ES the deterministic-local and stochastic-global
+    gradients of one smoothing operation, and that the Gygax–Zenke asymmetry (ES
+    smooths a real loss; the surrogate does not) is exactly what a hybrid
+    orthogonal-ES correction should target. We state this as a conceptual synthesis
+    and an invitation to be corrected, **not** a novelty claim on either leg.
+
+### References
+
+- Y. Nesterov, V. Spokoiny (2017). *Random Gradient-Free Minimization of Convex
+  Functions.* Foundations of Computational Mathematics.
+- T. Salimans, J. Ho, X. Chen, S. Sidor, I. Sutskever (2017). *Evolution
+  Strategies as a Scalable Alternative to Reinforcement Learning.*
+  arXiv:1703.03864.
+- E. O. Neftci, H. Mostafa, F. Zenke (2019). *Surrogate Gradient Learning in
+  Spiking Neural Networks.* IEEE Signal Processing Magazine. arXiv:1901.09948.
+- F. Zenke, S. Ganguli (2018). *SuperSpike: Supervised Learning in Multilayer
+  Spiking Neural Networks.* Neural Computation.
+- F. Zenke, T. P. Vogels (2021). *The Remarkable Robustness of Surrogate Gradient
+  Learning for Instilling Complex Function in Spiking Neural Networks.* Neural
+  Computation.
+- J. Gygax, F. Zenke (2025). *Elucidating the Theoretical Underpinnings of
+  Surrogate Gradient Learning in Spiking Neural Networks.* Neural Computation.
+  arXiv:2404.14964.
+- Y. Wang et al. (2023). *Adaptive Smoothing Gradient Learning for Spiking Neural
+  Networks.* ICML.
+- Y. Bengio, N. Léonard, A. Courville (2013). *Estimating or Propagating Gradients
+  Through Stochastic Neurons.* arXiv:1308.3432 (straight-through estimator).
+- N. Maheswaranathan, L. Metz, G. Tucker, D. Choi, J. Sohl-Dickstein (2019).
+  *Guided Evolutionary Strategies.* arXiv:1806.10230 (the in-subspace complement of
+  the orthogonal correction).
+
+### See also in Spyx
+
+- [`spyx.axn`](../reference/axn.md) — the surrogate kernels tabulated above.
+- [`spyx.experimental.hybrid`](../reference/experimental.md) — surrogate + orthogonal-ES.
+- [`spyx.experimental.stochastic`](../reference/experimental.md) — `SPSN`, the exact-coincidence object.
+- [Training methods](training-methods.md) · [Choosing an approach](choosing-an-approach.md).

--- a/docs/explanation/training-methods.md
+++ b/docs/explanation/training-methods.md
@@ -1,0 +1,249 @@
+# Training methods
+
+There is no single way to train a spiking network. The methods differ in **what
+information about the loss they exploit** — and that choice, more than any
+architectural detail, decides which problems a method can solve, how fast it
+converges, and whether the thing you train is faithful to the hard-spike model
+you will eventually deploy.
+
+This page organises Spyx's training methods by the **order of information** they
+use, from zeroth-order (only loss *values*) up through first-order (loss
+*gradients*), the transfer methods that reuse an already-trained model, the
+local/bio-inspired family (mostly roadmap in Spyx today), and a hybrid that
+combines a first-order bulk direction with a zeroth-order error correction. For
+each method you get the same three things: **when to use it**, **the trade-off**,
+and **the Spyx entry point**.
+
+If you already know your task and just want to be pointed at a method, jump to
+[Choosing an approach](choosing-an-approach.md) and read this page for the *why*.
+
+## The ladder of information
+
+A training method can only use the information it asks for:
+
+| Order | What it sees | Differentiable forward needed? | Family |
+|---|---|---|---|
+| **0th** | loss *values* at sampled parameters | no | evolutionary / ES |
+| **1st** | loss *gradient* via a surrogate | yes (surrogate) | surrogate-gradient BPTT |
+| **transfer** | a pretrained ANN / an fp32 SNN | reuses another method | conversion & QAT |
+| **local** | per-layer signals, no global backprop | partial | feedback alignment, e-prop, synthetic grads |
+| **0+1 hybrid** | surrogate gradient **+** sampled hard-spike loss | yes (surrogate) | evolutionary error-correction |
+
+The higher the order, the cheaper the descent — a gradient points you straight
+downhill, whereas value-only search has to *discover* the direction from
+samples. But higher order also demands more structure: a first-order method needs
+the forward pass to be (surrogate-)differentiable, which a hard spike is not.
+Every method below is a different answer to that tension.
+
+## 0th-order — evolutionary / neuroevolution
+
+**Idea.** Never differentiate anything. Keep a search distribution over parameter
+vectors, sample a *population*, evaluate the true loss of each sample, and move
+the distribution toward the samples that scored well. Evolution strategies (ES)
+estimate a search gradient from those fitness values alone.
+
+**When to use it.**
+
+- The forward pass is **non-differentiable** end to end — a discrete environment,
+  a black-box simulator, a non-differentiable reward — so no surrogate exists.
+- You want to optimise the **hardware-faithful hard-spike loss directly**, with no
+  surrogate approximation in the loop, accepting that you pay for it in samples.
+- **Reinforcement-learning / control** with short episodes and small networks,
+  where a gradient through the environment is unavailable or high-variance and the
+  population evaluates embarrassingly in parallel under `jax.vmap`.
+
+**The trade-off.** Sample complexity. ES needs many forward evaluations per update
+and its variance grows with the parameter count, so it does not scale to large
+classifiers or language models the way gradient descent does. In exchange you get
+a method that is indifferent to non-differentiability and optimises exactly the
+objective you deploy.
+
+**Spyx entry point.** Spyx leans on
+[`evosax`](https://github.com/RobertTLange/evosax) (installed via the `[evo]`
+extra) for the algorithms; the network is a plain `nnx.Module` whose parameters
+you flatten into the ES search vector.
+
+- Algorithms to reach for: `evosax.algorithms.Open_ES` (the OpenAI-ES baseline),
+  `SNES` (separable natural ES — a strong, cheap default), and `GuidedES` (feeds a
+  surrogate gradient *into* the search — see the hybrid section, which is its
+  complement).
+- The [Cartpole Evolution notebook](../examples/neuroevolution/cartpole_evo.ipynb)
+  is the worked control example.
+- A packaged control recipe is being staged at **`spyx.experimental.zoo`** — import
+  it as `from spyx.experimental.zoo import ...` — so the population loop, fitness
+  shaping, and parameter (un)flattening don't have to be re-derived per study.
+- The neuroevolution notebooks under
+  [`research/misc/`](https://github.com/kmheckel/spyx/tree/main/research/misc)
+  (`nmnist_evo_*`, `shd_evo_*`) are additional starting points.
+
+## 1st-order — surrogate gradient (the workhorse)
+
+**Idea.** The spike \(S = H(V-\theta)\) has a derivative that is zero almost
+everywhere and undefined at threshold, so backprop-through-time (BPTT) would see
+no gradient. A **surrogate gradient** keeps the hard Heaviside on the *forward*
+pass but substitutes a smooth, bounded pseudo-derivative on the *backward* pass.
+The network is then trained by ordinary BPTT with Optax.
+
+**When to use it.** This is the **default** for almost everything: classification,
+sequence modelling, and any task where you have labelled data and a
+(surrogate-)differentiable forward pass. It is by far the most sample-efficient
+option here and scales with the usual deep-learning machinery (`jit`, `vmap`,
+Optax, quantization).
+
+**The trade-off.** The gradient is *biased* — it is not the gradient of the
+hard-spike loss, because that gradient does not exist. The surrogate is a modelling
+choice (its shape and steepness `k` are hyperparameters), and there is a subspace
+of directions in which the surrogate is systematically blind to how the true
+hard-spike loss changes. Usually the bias is benign; when it is not, the hybrid
+method below exists to correct it.
+
+**Spyx entry point.**
+
+- [`spyx.axn`](../reference/axn.md) provides the surrogate factories —
+  `superspike`, `arctan`, `tanh`, `triangular`, `boxcar` — each a
+  `jax.custom_gradient` you attach to a neuron — plus `heaviside`, the plain
+  step whose gradient is straight-through.
+- [`spyx.optimize.fit`](../reference/optimize.md) (and `make_train_step` /
+  `make_eval_step`) wrap the canonical `nnx.Optimizer(model, tx, wrt=nnx.Param)`
+  + `nnx.value_and_grad` loop so you don't re-write the epoch boilerplate.
+- The [Surrogate Gradient Tutorial](../examples/surrogate_gradient/SurrogateGradientTutorial.ipynb)
+  is the end-to-end walkthrough, with the
+  [surrogate](../examples/surrogate_gradient/shd_sg_surrogate_comparison.ipynb) and
+  [neuron-model](../examples/surrogate_gradient/shd_sg_neuron_model_comparison.ipynb)
+  comparisons as follow-ups.
+
+See the [SNN primer](snn-primer.md) for the mechanics of the surrogate and why the
+hard spike has no usable gradient.
+
+## Transfer — conversion & quantization-aware training
+
+**Idea.** Don't train the SNN from scratch — **inherit** from an already-trained
+model, then adapt. Two flavours:
+
+- **ANN→SNN conversion.** Map a trained real-valued network onto a spiking one by
+  reinterpreting activations as firing rates (rate coding), so a ReLU MLP/CNN
+  becomes a rate-coded SNN with little or no retraining.
+- **Quantization-aware training (QAT).** Start from an fp32 SNN and *fine-tune it
+  to be robust to low-precision weights/activations*, so it stays accurate after
+  int8 / int4 / ternary quantization for deployment.
+
+**When to use it.** You already have a strong fp32 model (yours or off the shelf)
+and want a spiking or low-precision version without paying full training cost, or
+you are targeting an efficiency/energy budget (memory-bound deployment,
+neuromorphic silicon) and need the accuracy/precision frontier quantified.
+
+**The trade-off.** Conversion inherits the source model's inductive biases and
+typically needs longer time windows `T` to let rates converge, trading latency for
+accuracy; it rarely beats a natively-trained temporal SNN on genuinely temporal
+tasks. QAT adds a fake-quantization step to every training iteration and its own
+hyperparameters (which layers, which qtype).
+
+**Spyx entry point.**
+
+- [`spyx.quant`](../reference/quant.md) supplies the QAT machinery: `quantize(model,
+  *example_inputs, mode="qat")` plus rule builders — `linear_only_rules`,
+  `weights_only_rules`, `bitnet_ternary_rules`, and `spiking_feedforward_rules`
+  (weight-only, **lossless on binary spike activations** because a spike is already
+  exactly `{0,1}` on the integer grid). `binary_activation_error` proves that
+  losslessness argument / catches graded surrogate activations.
+- The [Quantization-Aware Training notebook](../examples/quantization/qat_intro.ipynb)
+  is the walkthrough; the [quantize how-to](../how-to/quantize.md) is the recipe.
+- Conversion and transfer studies live under
+  [`research/new/`](https://github.com/kmheckel/spyx/tree/main/research/new) —
+  e.g. [`ssm_to_spiking_transfer/`](https://github.com/kmheckel/spyx/tree/main/research/new/ssm_to_spiking_transfer)
+  (transferring SSM dynamics into a spiking model) and
+  [`pretrain_finetune_curriculum/`](https://github.com/kmheckel/spyx/tree/main/research/new/pretrain_finetune_curriculum)
+  — and the [`reproductions/qs5/`](https://github.com/kmheckel/spyx/tree/main/research/reproductions/qs5)
+  quantized-S5 reproduction.
+
+!!! note "A binary-spike quantization win"
+    Because spike activations are already binary, quantizing **only the weights** on
+    the spike→Linear path adds *zero* activation-side error — the recipe
+    `spyx.quant.spiking_feedforward_rules` builds exactly this, and it is a genuine
+    free efficiency gain rather than an accuracy trade.
+
+## Local / bio-inspired — mostly roadmap
+
+**Idea.** Global BPTT is biologically implausible and memory-hungry (it stores the
+whole `[T, B, …]` activation history). The *local learning* family replaces the
+exact backward pass with signals available locally in space and/or time:
+
+- **Feedback alignment** — replace the transposed forward weights in the backward
+  pass with fixed random feedback, removing weight transport.
+- **Synthetic / decoupled gradients** — a small auxiliary network *predicts* the
+  gradient for a layer, so layers update without waiting for a full backward pass.
+- **e-prop (eligibility propagation)** — an online, forward-in-time approximation
+  to BPTT for recurrent SNNs using per-synapse eligibility traces, so you never
+  unroll the whole sequence.
+
+**Honest status in Spyx.** These are **research directions, not shipped APIs**.
+Spyx today gives you the substrate they need — `jax.custom_gradient` surrogates in
+[`spyx.axn`](../reference/axn.md), plain `nnx.Param` state you can attach traces to,
+and the `(x, state) -> (out, state)` neuron contract that an online rule slots into
+— but there is **no** `spyx.axn.feedback_alignment` or `spyx.optimize.eprop` to
+call. Treat this family as **aspirational**:
+
+- **Synthetic / decoupled gradients** — tracked in
+  [issue #27](https://github.com/kmheckel/spyx/issues/27).
+- **e-prop** — tracked in [issue #28](https://github.com/kmheckel/spyx/issues/28).
+
+**When it will matter.** Online, memory-bounded training (long sequences where
+storing the BPTT history is the bottleneck) and neuromorphic on-chip learning,
+where locality is a hardware constraint rather than a preference. Until the issues
+above land, use surrogate-gradient BPTT and, for the memory pressure specifically,
+[`spyx.experimental.compress`](../reference/experimental.md) (bit-packed activation
+storage) as the pragmatic stopgap.
+
+## 0+1 hybrid — evolutionary error-correction of the surrogate gradient
+
+**Idea.** Combine the two cheapest sources of information so each covers the
+other's blind spot. The surrogate gradient (1st-order) gives a cheap, low-variance
+**bulk descent direction** — but it is *biased*, blind to a subspace of how the
+**true hard-spike loss** actually moves. So estimate a small correction in exactly
+that blind subspace with a zeroth-order method:
+
+1. Take the surrogate gradient \(g_s\) as the bulk step (cheap, most of the signal).
+2. Form a small **antithetic ES** estimate \(g_h\) of the gradient of the *true
+   hard-spike loss* — a handful of paired \(\pm\varepsilon\) perturbations scored on
+   the real, non-differentiable forward pass.
+3. **Project \(g_h\) orthogonal to \(g_s\)** and add it back as an error correction:
+
+$$
+g \;=\; g_s \;+\; \big(g_h - \tfrac{\langle g_h, g_s\rangle}{\langle g_s, g_s\rangle}\, g_s\big).
+$$
+
+The projection is the whole point: the surrogate already owns the direction it
+points, so you only spend ES samples on the **complementary** subspace it cannot
+see. This is precisely the **complement of Guided-ES**, which does the opposite —
+it searches *within* the surrogate-gradient subspace to accelerate along a
+direction it already trusts. Here we spend the samples *outside* that subspace,
+where the surrogate is wrong.
+
+**When to use it.** The surrogate-gradient model trains but plateaus or drifts
+from the hard-spike model you deploy — i.e. the surrogate bias is costing you real
+accuracy — and you can afford a modest population of extra hard-forward
+evaluations per step. It is a targeted fix, not a default; reach for it when plain
+1st-order under-delivers on the *hard* objective.
+
+**The trade-off.** Each step now costs the surrogate backward pass **plus** a small
+antithetic ES batch of hard-spike forward passes — more compute per update than
+pure 1st-order, far less than pure 0th-order — in exchange for a descent direction
+that is unbiased in the subspace the surrogate misses.
+
+**Spyx entry point.** The concrete implementation is being staged at
+**`spyx.experimental.hybrid`** (import as `from spyx.experimental.hybrid import
+...`). Until it lands you can assemble the pieces by hand:
+[`spyx.axn`](../reference/axn.md) for \(g_s\), `evosax`'s antithetic sampling for
+\(g_h\), and a projection you drop into your `nnx.value_and_grad` step.
+
+## Summary
+
+| Method | Uses | Best for | Cost | Spyx entry point |
+|---|---|---|---|---|
+| **Evolutionary** | loss values | control/RL, non-differentiable or hard-spike objectives | many forward evals | `evosax` + `spyx.experimental.zoo` |
+| **Surrogate gradient** | surrogate loss gradient | classification, sequence modelling — the default | 1 fwd+bwd / step | [`spyx.axn`](../reference/axn.md) + [`spyx.optimize.fit`](../reference/optimize.md) |
+| **Conversion & QAT** | a pretrained model | deploying an existing model spiking / low-precision | fine-tune, longer `T` | [`spyx.quant`](../reference/quant.md) |
+| **Local / bio-inspired** | local signals | online / on-chip learning | — (roadmap) | issues [#27](https://github.com/kmheckel/spyx/issues/27), [#28](https://github.com/kmheckel/spyx/issues/28) |
+| **0+1 hybrid** | surrogate grad + hard-spike ES | fixing surrogate bias on the hard objective | fwd+bwd **+** small ES batch | `spyx.experimental.hybrid` |
+
+Now pick one for *your* task and architecture: [Choosing an approach](choosing-an-approach.md).

--- a/docs/explanation/training-methods.md
+++ b/docs/explanation/training-methods.md
@@ -113,7 +113,10 @@ method below exists to correct it.
   comparisons as follow-ups.
 
 See the [SNN primer](snn-primer.md) for the mechanics of the surrogate and why the
-hard spike has no usable gradient.
+hard spike has no usable gradient, and
+[Surrogate gradients & Gaussian smoothing](surrogate-gradients-and-gaussian-smoothing.md)
+for why a surrogate derivative is a smoothing kernel — and how that makes it the
+activation-space twin of evolution strategies.
 
 ## Transfer — conversion & quantization-aware training
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,15 @@ These docs follow the [Diátaxis](https://diataxis.fr) framework: four sections,
 
 **Want to understand why?** Background and design discussion, read away from the keyboard.
 
+!!! tip "Not sure how to train your model? Start here."
+    [**Choosing an approach**](explanation/choosing-an-approach.md) turns the
+    [training-methods spine](explanation/training-methods.md) into a decision:
+    pick a training method by the *kind of information* it uses (evolutionary,
+    surrogate-gradient, conversion/QAT, local, or the 0+1 hybrid), then see which
+    applications and architectures it fits, and where the Spyx entry points are.
+
+- [Training methods](explanation/training-methods.md) — the method spine: evolutionary, surrogate-gradient, conversion/QAT, local/bio-inspired, and the 0+1 hybrid, each with when-to-use, the trade-off, and the Spyx entry point.
+- [Choosing an approach](explanation/choosing-an-approach.md) — decision matrices (method × application, method × architecture) plus a task → application → architecture → method flow.
 - [Design and architecture](explanation/design.md) — why Spyx is built the way it is, the module map, and how it compares to PyTorch SNN libraries.
 - [A primer on spiking neural networks](explanation/snn-primer.md) — spikes, LIF dynamics, surrogate gradients, and rate vs. latency coding.
 - [Parallel spiking neurons](explanation/parallel-spiking-neurons.md) — reset-free, associative-scan neurons that train in `O(log T)` depth.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Explanation:
       - Training methods: explanation/training-methods.md
       - Choosing an approach: explanation/choosing-an-approach.md
+      - Surrogate gradients & Gaussian smoothing: explanation/surrogate-gradients-and-gaussian-smoothing.md
       - Design & architecture: explanation/design.md
       - SNN primer: explanation/snn-primer.md
       - Parallel spiking neurons: explanation/parallel-spiking-neurons.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,8 @@ nav:
       - spyx.bench: reference/bench.md
       - spyx.experimental: reference/experimental.md
   - Explanation:
+      - Training methods: explanation/training-methods.md
+      - Choosing an approach: explanation/choosing-an-approach.md
       - Design & architecture: explanation/design.md
       - SNN primer: explanation/snn-primer.md
       - Parallel spiking neurons: explanation/parallel-spiking-neurons.md

--- a/research/new/hybrid_evo_surrogate/README.md
+++ b/research/new/hybrid_evo_surrogate/README.md
@@ -36,20 +36,25 @@ That makes `g = g_s + λ·g_orth` fragile: unless `λ` is small the orthogonal E
 term dominates and drags the update toward ES noise. We expect the interesting
 regime to be a well-matched-but-large-bias surrogate with large `K` and a small,
 tuned `λ`; in the cheap smoke regime we expect hybrid to be *pulled below* the
-surrogate rather than to beat it, and we report exactly that.
+surrogate rather than to beat it, and we report exactly that — then test the
+obvious fix (a self-normalising `λ`) and report where it lands (see Findings).
 
 ## Method
 
 - **Task:** a tiny synthetic spiking classification problem — each class owns a
   band of input channels that spike at an elevated rate; a `Linear → LIF →
   Linear → LI` classifier reads the summed membrane trace (`spyx.fn.integral_*`).
-- **Three arms**, identical init, identical optimizer (`optax.adam`), identical
+- **Four arms**, identical init, identical optimizer (`optax.adam`), identical
   step budget:
   1. **surrogate** — pure `∇ loss_surrogate` (`spyx.axn` superspike backward).
   2. **es** — pure antithetic NES on the true (hard-spike forward) loss
      (`spyx.experimental.hybrid.es_gradient`), no surrogate at all.
-  3. **hybrid** — `spyx.experimental.hybrid.make_hybrid_train_step`
-     (`g_s + λ·g_orth`).
+  3. **hybrid-raw** — `make_hybrid_train_step(..., normalize=False)`
+     (`g_s + λ·g_orth`, raw `λ`; the original PR #49 setting).
+  4. **hybrid-norm** — `make_hybrid_train_step(..., normalize=True)`, where `λ` is
+     a dimensionless *fraction of the surrogate step*: the correction is rescaled
+     to `‖λ·‖g_s‖‖` via `λ_eff = λ·‖g_s‖/‖g_orth‖`, so the ES term can never swamp
+     the bulk direction regardless of its variance.
 - **True vs. surrogate loss:** both are `integral_crossentropy`. They share the
   *same* forward (every `spyx.axn` activation forwards through the identical
   Heaviside step), so the "true" loss is the hard-spike forward loss; they differ
@@ -75,11 +80,15 @@ runs the fuller config without the flag.
 ## How to run
 
 ```bash
-SPYX_SMOKE=1 uv run python research/new/hybrid_evo_surrogate/run.py   # seconds, CPU
+SPYX_SMOKE=1 uv run python research/new/hybrid_evo_surrogate/run.py   # 4-arm demo, seconds
 uv run python research/new/hybrid_evo_surrogate/run.py                # fuller config
+uv run python research/new/hybrid_evo_surrogate/sweep.py              # multi-seed sweep
 ```
 
-No dataset download — the task is synthetic and generated in-process.
+No dataset download — the task is synthetic and generated in-process. `sweep.py`
+sweeps seeds × ES sample count `K` × correction fraction `λ` over a harder regime
+and reports the mean Δ(true_loss) = hybrid-norm − surrogate with its seed spread,
+so a claimed "win" has to survive noise (writes `sweep_results.json`).
 
 ## Results
 
@@ -90,37 +99,56 @@ run on CPU (seed 0); numbers are tiny-regime and illustrative, not a benchmark:
 | --- | --- | --- | --- |
 | surrogate | see JSON | see JSON | pure `∇` surrogate |
 | es | see JSON | see JSON | pure antithetic NES |
-| hybrid | see JSON | see JSON | `g_s + λ·g_orth` |
+| hybrid-raw | see JSON | see JSON | `g_s + λ·g_orth`, raw `λ` |
+| hybrid-norm | see JSON | see JSON | self-normalised `λ` (fraction of step) |
 
-Hybrid diagnostics (mean over steps): `cosine(g_es, g_s)`, `‖g_orth‖` — see JSON.
+Hybrid diagnostics (mean over steps): `cosine(g_es, g_s)`, `‖g_orth‖`,
+`correction_fraction` — see JSON. See the Findings section for the multi-seed
+`sweep.py` verdict.
 
 ## Findings
 
-Honest reading of the `SPYX_SMOKE=1` run (seed 0; exact numbers in
-`study_results.json`):
+**1. The raw-`λ` failure mode is real** (`SPYX_SMOKE=1`, `study_results.json`).
+Pure surrogate reaches ~1.47 true loss; pure ES trails at ~2.68; **hybrid-raw is
+*dragged below* the surrogate at ~2.53**. Diagnostics explain why: `‖g_orth‖ ≈ 41`
+vs `‖g_s‖ ≈ 8.6` (correction ~5× the bulk direction) with `cosine(g_es, g_s) ≈
+0.28`, so at `λ = 0.5` the noisy ES term dominates the update. "Orthogonalise +
+add" is *not* free — the correction magnitude has to be controlled.
 
-- **Surrogate wins in this regime.** Pure surrogate descent reaches the lowest
-  true loss (~1.47, ~33% acc on a 3-class toy). It is also the cheapest arm by
-  far — one `jax.grad` per step vs. `2K` forward evals for the ES/hybrid arms.
-- **Pure ES is the weakest arm** (true loss ~2.68). Antithetic NES on a
-  Gaussian-smoothed Heaviside loss is high-variance with a small sample budget,
-  so it learns slowly.
-- **Hybrid is *dragged below* the surrogate, not lifted above it** (true loss
-  ~2.53). The diagnostics explain why: measured `‖g_orth‖ ≈ 41` while
-  `‖g_s‖ ≈ 8.6`, i.e. the orthogonal ES correction is ~5× larger in magnitude
-  than the surrogate bulk direction, and `cosine(g_es, g_s) ≈ 0.28` (weak
-  alignment, so most of `g_es` survives the projection). With `λ = 0.5` the
-  update is dominated by noisy ES, and hybrid ends up tracking ES rather than
-  the surrogate. This refutes the naive hope that "orthogonalise + add" is
-  free — **`λ` must be scaled to `‖g_s‖ / ‖g_orth‖`, not set to O(1)**.
-- **Net:** a negative/boundary result in the cheap regime, reported as such per
-  the research guidance. The method is only plausible when (a) the surrogate is
-  genuinely biased, (b) `K` is large enough to shrink ES variance, and (c) `λ`
-  is small / adaptively normalised so the correction never overwhelms the bulk
-  direction. The mechanics (global orthogonalisation, drop-in grad pytree) are
-  verified and correct; the *win* is not demonstrated here and we do not claim
-  it. A natural follow-up is a self-normalising `λ_eff = λ · ‖g_s‖ / (‖g_orth‖ +
-  eps)`.
+**2. Self-normalising `λ` fixes the failure mode and is safe.** Reinterpreting `λ`
+as a fraction of the surrogate step (`normalize=True`,
+`λ_eff = λ·‖g_s‖/‖g_orth‖`) removes the blow-up: in the same smoke regime
+hybrid-norm recovers to ~1.93 (from raw's 2.53). The multi-seed `sweep.py` on a
+harder regime (24ch/32h/4-class, 20 epochs, surrogate floor ≈ 0.684) confirms it
+holds across seeds — at `K = 32`:
+
+| λ (fraction) | surrogate | hybrid-norm | hybrid-raw | Δ(norm−sur) | wins |
+| --- | --- | --- | --- | --- | --- |
+| 0.15 | 0.684 | 0.688 | 0.776 | +0.004 ± 0.011 | 1/3 |
+| 0.30 | 0.684 | 0.697 | 0.776 | +0.014 ± 0.009 | 0/3 |
+| 0.50 | 0.684 | 0.707 | 0.776 | +0.024 ± 0.019 | 1/3 |
+
+hybrid-raw sits at 0.776 across the board (the same drag); hybrid-norm tracks the
+surrogate closely and the gap *grows with `λ`*, exactly as the fraction
+interpretation predicts. (The `K = 96` cells were not completed in this run.)
+
+**3. But it does not *beat* the surrogate on these easy tasks.** At the smallest
+fraction (`λ = 0.15`) hybrid-norm reaches parity within seed noise (Δ = +0.004,
+one seed of three actually wins), and it never clears the surrogate on average.
+The reason is a task ceiling, not an implementation gap: the surrogate is already
+a good descent direction here and sits near the achievable floor, so there is
+little bias left for an orthogonal correction to remove, and the residual ES
+variance costs slightly more than the correction is worth.
+
+**Net.** The self-normalising `λ` turns a *fragile* method (hybrid-raw, which can
+end up much worse than plain surrogate) into a *safe* one (hybrid-norm ≈ surrogate,
+never catastrophically worse) — a real, verified improvement over the PR #49
+version. The stronger claim — that the orthogonal-ES correction *beats* surrogate
+descent — remains **unproven**; it needs a regime with genuinely large surrogate
+bias (mismatched surrogate, deeper/recurrent nets, or a hard-spike objective that
+truly diverges from the smooth one) and larger `K`. We report parity-plus-safety,
+not a win, and do not overclaim. The mechanics (global orthogonalisation, exact
+`λ·‖g_s‖` scaling, drop-in grad pytree) are unit-tested and correct.
 
 ## Reproducibility
 
@@ -130,4 +158,5 @@ Honest reading of the `SPYX_SMOKE=1` run (seed 0; exact numbers in
   requirement). Timing is not the point of this study; correctness of the
   three-arm comparison is.
 - **Spyx commit:** record `git rev-parse HEAD` at run time.
-- **Date run:** 2026-07-04 (initial).
+- **Date run:** 2026-07-04 (initial three-arm study; self-normalising `λ` +
+  multi-seed sweep added same day).

--- a/research/new/hybrid_evo_surrogate/README.md
+++ b/research/new/hybrid_evo_surrogate/README.md
@@ -1,0 +1,133 @@
+# Hybrid surrogate + orthogonalised evolutionary correction
+
+## Title
+
+Correcting surrogate-gradient bias in spiking nets with an orthogonalised
+evolutionary error term.
+
+## Paper & arXiv/DOI
+
+- **Title:** novel — no paper yet. Closest prior art: **Guided Evolutionary
+  Strategies** (Maheswaranathan, Metz, Tucker, Choi, Sohl-Dickstein 2019,
+  arXiv:1806.10230), which restricts the ES search to the *surrogate's* subspace.
+  This study does the complement: restrict ES to the surrogate's *orthogonal
+  complement* and use it as an additive correction.
+- **Authors / venue / year:** N/A (Spyx research note).
+- **Bucket:** new
+
+## Claim under test
+
+Surrogate-gradient descent through hard-spiking neurons is cheap but *biased*:
+the true forward objective uses a Heaviside spike whose gradient is zero almost
+everywhere, so the backward pass substitutes a smooth surrogate and descends a
+*related* landscape. **Hypothesis:** an antithetic-NES estimate of the true
+(hard-spike) loss gradient, projected onto the subspace the surrogate does *not*
+already cover (`g_orth = g_es − ⟨g_es, ĝ_s⟩ ĝ_s`) and added back as
+`g = g_s + λ·g_orth`, corrects that bias and reaches a lower **true** loss than
+either pure surrogate descent or pure ES under a matched step budget.
+
+**Honest expected outcome.** This is a boundary-result-prone idea. Pure ES is
+unbiased but high-variance; on a Gaussian-smoothed Heaviside loss its signal is
+weak in the parameter dimension, so with a small sample budget `K` the ES
+estimate is noisy. Crucially, that noise is *not* small in magnitude — an
+antithetic NES estimate `g_es = coeff·ε` has norm that grows with the parameter
+dimension and the loss curvature, so `‖g_orth‖` can easily *exceed* `‖g_s‖`.
+That makes `g = g_s + λ·g_orth` fragile: unless `λ` is small the orthogonal ES
+term dominates and drags the update toward ES noise. We expect the interesting
+regime to be a well-matched-but-large-bias surrogate with large `K` and a small,
+tuned `λ`; in the cheap smoke regime we expect hybrid to be *pulled below* the
+surrogate rather than to beat it, and we report exactly that.
+
+## Method
+
+- **Task:** a tiny synthetic spiking classification problem — each class owns a
+  band of input channels that spike at an elevated rate; a `Linear → LIF →
+  Linear → LI` classifier reads the summed membrane trace (`spyx.fn.integral_*`).
+- **Three arms**, identical init, identical optimizer (`optax.adam`), identical
+  step budget:
+  1. **surrogate** — pure `∇ loss_surrogate` (`spyx.axn` superspike backward).
+  2. **es** — pure antithetic NES on the true (hard-spike forward) loss
+     (`spyx.experimental.hybrid.es_gradient`), no surrogate at all.
+  3. **hybrid** — `spyx.experimental.hybrid.make_hybrid_train_step`
+     (`g_s + λ·g_orth`).
+- **True vs. surrogate loss:** both are `integral_crossentropy`. They share the
+  *same* forward (every `spyx.axn` activation forwards through the identical
+  Heaviside step), so the "true" loss is the hard-spike forward loss; they differ
+  only in the backward pass — the surrogate arm backprops through the smooth
+  surrogate, the ES arm never differentiates at all. This is exactly the
+  `loss_true = hard-spike forward eval` case in the algorithm.
+- **Measured:** final **true** cross-entropy and accuracy per arm, plus the
+  hybrid diagnostics (`cosine` between `g_es` and `g_s`, `‖g_orth‖`) so the
+  correction magnitude is visible.
+
+`SMOKE=1` shrinks every dimension (channels, hidden, time, samples, epochs) so
+the whole three-arm comparison runs on CPU in a few seconds; the same code path
+runs the fuller config without the flag.
+
+## Spyx modules used
+
+- [`spyx.experimental.hybrid`](../../../src/spyx/experimental/hybrid.py) —
+  `hybrid_gradient`, `es_gradient`, `make_hybrid_train_step`, `hybrid_diagnostics`
+- [`spyx.nn.LIF`](../../../src/spyx/nn.py) / `LI` / `Sequential` / `run`
+- [`spyx.axn.superspike`](../../../src/spyx/axn.py)
+- [`spyx.fn.integral_crossentropy`](../../../src/spyx/fn.py) / `integral_accuracy`
+
+## How to run
+
+```bash
+SPYX_SMOKE=1 uv run python research/new/hybrid_evo_surrogate/run.py   # seconds, CPU
+uv run python research/new/hybrid_evo_surrogate/run.py                # fuller config
+```
+
+No dataset download — the task is synthetic and generated in-process.
+
+## Results
+
+Filled in by `run.py` (writes `study_results.json`). Representative `SPYX_SMOKE=1`
+run on CPU (seed 0); numbers are tiny-regime and illustrative, not a benchmark:
+
+| Arm | Final true loss | Accuracy | Notes |
+| --- | --- | --- | --- |
+| surrogate | see JSON | see JSON | pure `∇` surrogate |
+| es | see JSON | see JSON | pure antithetic NES |
+| hybrid | see JSON | see JSON | `g_s + λ·g_orth` |
+
+Hybrid diagnostics (mean over steps): `cosine(g_es, g_s)`, `‖g_orth‖` — see JSON.
+
+## Findings
+
+Honest reading of the `SPYX_SMOKE=1` run (seed 0; exact numbers in
+`study_results.json`):
+
+- **Surrogate wins in this regime.** Pure surrogate descent reaches the lowest
+  true loss (~1.47, ~33% acc on a 3-class toy). It is also the cheapest arm by
+  far — one `jax.grad` per step vs. `2K` forward evals for the ES/hybrid arms.
+- **Pure ES is the weakest arm** (true loss ~2.68). Antithetic NES on a
+  Gaussian-smoothed Heaviside loss is high-variance with a small sample budget,
+  so it learns slowly.
+- **Hybrid is *dragged below* the surrogate, not lifted above it** (true loss
+  ~2.53). The diagnostics explain why: measured `‖g_orth‖ ≈ 41` while
+  `‖g_s‖ ≈ 8.6`, i.e. the orthogonal ES correction is ~5× larger in magnitude
+  than the surrogate bulk direction, and `cosine(g_es, g_s) ≈ 0.28` (weak
+  alignment, so most of `g_es` survives the projection). With `λ = 0.5` the
+  update is dominated by noisy ES, and hybrid ends up tracking ES rather than
+  the surrogate. This refutes the naive hope that "orthogonalise + add" is
+  free — **`λ` must be scaled to `‖g_s‖ / ‖g_orth‖`, not set to O(1)**.
+- **Net:** a negative/boundary result in the cheap regime, reported as such per
+  the research guidance. The method is only plausible when (a) the surrogate is
+  genuinely biased, (b) `K` is large enough to shrink ES variance, and (c) `λ`
+  is small / adaptively normalised so the correction never overwhelms the bulk
+  direction. The mechanics (global orthogonalisation, drop-in grad pytree) are
+  verified and correct; the *win* is not demonstrated here and we do not claim
+  it. A natural follow-up is a self-normalising `λ_eff = λ · ‖g_s‖ / (‖g_orth‖ +
+  eps)`.
+
+## Reproducibility
+
+- **Seeds:** `jax.random.PRNGKey(0)` for perturbations/data; `nnx.Rngs(0)` for
+  model init; NumPy `default_rng(0)` for the synthetic dataset.
+- **JAX / hardware:** JAX 0.10.2, Flax 0.12.7, CPU (study forces no accelerator
+  requirement). Timing is not the point of this study; correctness of the
+  three-arm comparison is.
+- **Spyx commit:** record `git rev-parse HEAD` at run time.
+- **Date run:** 2026-07-04 (initial).

--- a/research/new/hybrid_evo_surrogate/run.py
+++ b/research/new/hybrid_evo_surrogate/run.py
@@ -1,0 +1,300 @@
+"""Three-arm study: surrogate vs. pure-ES vs. hybrid on a synthetic spiking task.
+
+See README.md for the hypothesis and honest expected outcome. In short: does the
+orthogonalised evolutionary correction in ``spyx.experimental.hybrid`` reach a
+lower *true* (hard-spike forward) loss than pure surrogate descent or pure ES,
+under a matched step budget?
+
+The three arms share init, optimizer, and step count; they differ only in how
+the gradient is built:
+
+* **surrogate** — ``∇ loss_surrogate`` via the ``spyx.axn`` superspike backward.
+* **es**        — pure antithetic NES on the true loss (no surrogate).
+* **hybrid**    — ``g_s + λ·g_orth`` (surrogate bulk + orthogonal ES correction).
+
+``loss_true`` and ``loss_surrogate`` are the *same* cross-entropy: every
+``spyx.axn`` activation forwards through the identical Heaviside step, so the
+"true" loss is the hard-spike forward loss and the arms differ only in the
+backward pass (surrogate differentiates it; ES only evaluates it).
+
+Run::
+
+    SPYX_SMOKE=1 uv run python research/new/hybrid_evo_surrogate/run.py   # seconds
+    uv run python research/new/hybrid_evo_surrogate/run.py                # fuller
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from flax import nnx
+
+import spyx.axn as axn
+import spyx.fn as fn
+import spyx.nn as snn
+from spyx.experimental.hybrid import (
+    es_gradient,
+    hybrid_diagnostics,
+    make_hybrid_train_step,
+)
+
+SMOKE = bool(os.environ.get("SPYX_SMOKE") or os.environ.get("SMOKE"))
+
+if SMOKE:
+    CHANNELS, HIDDEN, N_CLASSES, SAMPLE_T = 12, 12, 3, 8
+    N_TRAIN, N_TEST, BATCH = 24, 12, 12
+    EPOCHS = int(os.environ.get("EPOCHS", "8"))
+    K = int(os.environ.get("K", "16"))  # antithetic pairs
+else:
+    CHANNELS, HIDDEN, N_CLASSES, SAMPLE_T = 40, 48, 5, 24
+    N_TRAIN, N_TEST, BATCH = 256, 128, 64
+    EPOCHS = int(os.environ.get("EPOCHS", "30"))
+    K = int(os.environ.get("K", "64"))
+
+SIGMA = float(os.environ.get("SIGMA", "0.02"))
+LAM = float(os.environ.get("LAM", "0.5"))
+LR = float(os.environ.get("LR", "5e-3"))
+SEED = int(os.environ.get("SEED", "0"))
+
+
+# --------------------------------------------------------------------------- data
+def synthetic_data():
+    """Class-conditional band-rate spikes: each class fires an extra channel band.
+
+    Returns time-major ``(T, B, C)`` batches so they feed straight into
+    ``spyx.nn.run``. Enough signal that a spiking classifier can separate classes
+    on CPU in seconds — this exercises the arms, it is not a benchmark.
+    """
+    rng = np.random.default_rng(SEED)
+    band = max(1, CHANNELS // N_CLASSES)
+
+    def make(n):
+        labels = rng.integers(0, N_CLASSES, size=n)
+        x = (rng.random((n, SAMPLE_T, CHANNELS)) < 0.05).astype(np.float32)
+        for i in range(n):
+            lo = labels[i] * band
+            x[i, :, lo : lo + band] += (
+                rng.random((SAMPLE_T, band)) < 0.35
+            ).astype(np.float32)
+        return np.clip(x, 0.0, 1.0), labels.astype(np.int32)
+
+    xtr, ytr = make(N_TRAIN)
+    xte, yte = make(N_TEST)
+
+    def batched(x, y):
+        obs, lab = [], []
+        for s in range(0, x.shape[0] - BATCH + 1, BATCH):
+            # (B, T, C) -> (T, B, C) time-major for spyx.nn.run
+            obs.append(jnp.transpose(jnp.asarray(x[s : s + BATCH]), (1, 0, 2)))
+            lab.append(jnp.asarray(y[s : s + BATCH]))
+        return obs, lab
+
+    return batched(xtr, ytr), batched(xte, yte)
+
+
+# ------------------------------------------------------------------------- model
+class SpikingClassifier(nnx.Module):
+    """Linear -> LIF -> Linear -> LI over time; returns a (B, T, classes) trace."""
+
+    def __init__(self, activation, *, rngs):
+        self.net = snn.Sequential(
+            nnx.Linear(CHANNELS, HIDDEN, rngs=rngs),
+            snn.LIF((HIDDEN,), activation=activation, rngs=rngs),
+            nnx.Linear(HIDDEN, N_CLASSES, rngs=rngs),
+            snn.LI((N_CLASSES,), rngs=rngs),
+        )
+
+    def __call__(self, x_TBC):
+        traces, _ = snn.run(self.net, x_TBC)  # (T, B, classes)
+        return jnp.transpose(traces, (1, 0, 2))  # (B, T, classes)
+
+
+ce = fn.integral_crossentropy(smoothing=0.2)
+acc_fn = fn.integral_accuracy()
+
+
+def loss_fn(model, xb, yb):
+    return ce(model(xb), yb)
+
+
+def evaluate(model, test):
+    xs, ys = test
+    losses = jnp.stack([loss_fn(model, x, y) for x, y in zip(xs, ys)])
+    accs = jnp.stack([acc_fn(model(x), y)[0] for x, y in zip(xs, ys)])
+    return float(jnp.mean(losses)), float(jnp.mean(accs))
+
+
+def fresh_model():
+    # Identical init across arms (same seed).
+    return SpikingClassifier(axn.superspike(), rngs=nnx.Rngs(SEED))
+
+
+# ---------------------------------------------------------------------- train arms
+def train_surrogate(train, test):
+    """Pure surrogate-gradient descent (the cheap biased baseline)."""
+    model = fresh_model()
+    opt = nnx.Optimizer(model, optax.adam(LR), wrt=nnx.Param)
+
+    @nnx.jit
+    def step(m, o, xb, yb):
+        loss, g = nnx.value_and_grad(lambda mm: loss_fn(mm, xb, yb))(m)
+        o.update(m, g)
+        return loss
+
+    xs, ys = train
+    t0 = time.perf_counter()
+    for _ in range(EPOCHS):
+        for x, y in zip(xs, ys):
+            step(model, opt, x, y)
+    dt = time.perf_counter() - t0
+    tl, ta = evaluate(model, test)
+    return {"true_loss": tl, "acc": ta, "train_s": dt}
+
+
+def train_es(train, test):
+    """Pure antithetic-NES on the true (hard-spike forward) loss — no surrogate."""
+    model = fresh_model()
+    opt = nnx.Optimizer(model, optax.adam(LR), wrt=nnx.Param)
+    xs, ys = train
+    key = jax.random.PRNGKey(SEED)
+    t0 = time.perf_counter()
+    for _ in range(EPOCHS):
+        for x, y in zip(xs, ys):
+            key, sub = jax.random.split(key)
+            grads = es_gradient(
+                model, loss_fn, sub, batch=(x, y), num_samples=K, sigma=SIGMA
+            )
+            opt.update(model, grads)
+    dt = time.perf_counter() - t0
+    tl, ta = evaluate(model, test)
+    return {"true_loss": tl, "acc": ta, "train_s": dt}
+
+
+def train_hybrid(train, test):
+    """Hybrid g_s + lam * g_orth; also logs the mean correction diagnostics."""
+    model = fresh_model()
+    opt = nnx.Optimizer(model, optax.adam(LR), wrt=nnx.Param)
+    step = make_hybrid_train_step(
+        loss_fn, loss_fn, num_samples=K, sigma=SIGMA, lam=LAM
+    )
+    xs, ys = train
+    key = jax.random.PRNGKey(SEED)
+    cosines, orth_norms, s_norms = [], [], []
+    t0 = time.perf_counter()
+    for ep in range(EPOCHS):
+        for x, y in zip(xs, ys):
+            key, sub = jax.random.split(key)
+            step(model, opt, sub, x, y)
+            if ep == 0:  # sample the correction geometry on the first epoch
+                key, dk = jax.random.split(key)
+                d = hybrid_diagnostics(
+                    model, loss_fn, loss_fn, dk, batch=(x, y),
+                    num_samples=K, sigma=SIGMA, lam=LAM,
+                )
+                cosines.append(float(d["cosine"]))
+                orth_norms.append(float(d["g_orth_norm"]))
+                s_norms.append(float(d["g_s_norm"]))
+    dt = time.perf_counter() - t0
+    tl, ta = evaluate(model, test)
+    return {
+        "true_loss": tl,
+        "acc": ta,
+        "train_s": dt,
+        "diag": {
+            "mean_cosine_es_vs_surrogate": float(np.mean(cosines)) if cosines else None,
+            "mean_g_orth_norm": float(np.mean(orth_norms)) if orth_norms else None,
+            "mean_g_s_norm": float(np.mean(s_norms)) if s_norms else None,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------- main
+def main():
+    print(
+        f"backend={jax.default_backend()}  SMOKE={SMOKE}  "
+        f"C={CHANNELS} H={HIDDEN} classes={N_CLASSES} T={SAMPLE_T}  "
+        f"epochs={EPOCHS} K={K} sigma={SIGMA} lam={LAM}",
+        flush=True,
+    )
+    train, test = synthetic_data()
+    print(f"train batches={len(train[0])}  test batches={len(test[0])}\n", flush=True)
+
+    print("== 1. surrogate ==", flush=True)
+    r_sur = train_surrogate(train, test)
+    print(
+        f"  true_loss={r_sur['true_loss']:.4f}  acc={r_sur['acc'] * 100:.2f}%  "
+        f"({r_sur['train_s']:.2f}s)",
+        flush=True,
+    )
+
+    print("== 2. pure ES ==", flush=True)
+    r_es = train_es(train, test)
+    print(
+        f"  true_loss={r_es['true_loss']:.4f}  acc={r_es['acc'] * 100:.2f}%  "
+        f"({r_es['train_s']:.2f}s)",
+        flush=True,
+    )
+
+    print("== 3. hybrid ==", flush=True)
+    r_hy = train_hybrid(train, test)
+    print(
+        f"  true_loss={r_hy['true_loss']:.4f}  acc={r_hy['acc'] * 100:.2f}%  "
+        f"({r_hy['train_s']:.2f}s)",
+        flush=True,
+    )
+    d = r_hy["diag"]
+    print(
+        f"  diagnostics: mean cosine(g_es,g_s)={d['mean_cosine_es_vs_surrogate']}  "
+        f"mean ||g_orth||={d['mean_g_orth_norm']}  mean ||g_s||={d['mean_g_s_norm']}",
+        flush=True,
+    )
+
+    print("\n== three-arm comparison (final TRUE loss / accuracy) ==", flush=True)
+    rows = [("surrogate", r_sur), ("es", r_es), ("hybrid", r_hy)]
+    print(f"  {'arm':<10} {'true_loss':>10} {'accuracy':>10} {'train_s':>9}")
+    for name, r in rows:
+        print(
+            f"  {name:<10} {r['true_loss']:>10.4f} "
+            f"{r['acc'] * 100:>9.2f}% {r['train_s']:>9.2f}"
+        )
+
+    best = min(rows, key=lambda kv: kv[1]["true_loss"])[0]
+    print(f"\n  lowest true loss: {best}", flush=True)
+    print(
+        "  (honest note: in the smoke regime pure-ES trails and the ES "
+        "correction can exceed ||g_s|| in magnitude, dragging hybrid below the "
+        "surrogate unless lam is scaled down; see README.)",
+        flush=True,
+    )
+
+    out = {
+        "config": {
+            "smoke": SMOKE,
+            "channels": CHANNELS,
+            "hidden": HIDDEN,
+            "n_classes": N_CLASSES,
+            "sample_T": SAMPLE_T,
+            "epochs": EPOCHS,
+            "num_samples_K": K,
+            "sigma": SIGMA,
+            "lam": LAM,
+            "lr": LR,
+            "seed": SEED,
+        },
+        "results": {"surrogate": r_sur, "es": r_es, "hybrid": r_hy},
+        "lowest_true_loss_arm": best,
+    }
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "study_results.json"), "w") as f:
+        json.dump(out, f, indent=2)
+    print("\nwrote study_results.json", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/new/hybrid_evo_surrogate/run.py
+++ b/research/new/hybrid_evo_surrogate/run.py
@@ -58,7 +58,8 @@ else:
     K = int(os.environ.get("K", "64"))
 
 SIGMA = float(os.environ.get("SIGMA", "0.02"))
-LAM = float(os.environ.get("LAM", "0.5"))
+LAM = float(os.environ.get("LAM", "0.5"))  # raw-mode weight on g_orth
+LAM_NORM = float(os.environ.get("LAM_NORM", "0.3"))  # normalize-mode fraction
 LR = float(os.environ.get("LR", "5e-3"))
 SEED = int(os.environ.get("SEED", "0"))
 
@@ -176,16 +177,21 @@ def train_es(train, test):
     return {"true_loss": tl, "acc": ta, "train_s": dt}
 
 
-def train_hybrid(train, test):
-    """Hybrid g_s + lam * g_orth; also logs the mean correction diagnostics."""
+def train_hybrid(train, test, *, normalize, lam):
+    """Hybrid g_s + lam_eff * g_orth; logs the mean correction diagnostics.
+
+    ``normalize=False`` uses ``lam`` as a raw scale on ``g_orth``;
+    ``normalize=True`` treats ``lam`` as a fraction of the surrogate step so the
+    applied correction has norm ``lam·‖g_s‖`` (see ``spyx.experimental.hybrid``).
+    """
     model = fresh_model()
     opt = nnx.Optimizer(model, optax.adam(LR), wrt=nnx.Param)
     step = make_hybrid_train_step(
-        loss_fn, loss_fn, num_samples=K, sigma=SIGMA, lam=LAM
+        loss_fn, loss_fn, num_samples=K, sigma=SIGMA, lam=lam, normalize=normalize
     )
     xs, ys = train
     key = jax.random.PRNGKey(SEED)
-    cosines, orth_norms, s_norms = [], [], []
+    cosines, orth_norms, s_norms, fracs = [], [], [], []
     t0 = time.perf_counter()
     for ep in range(EPOCHS):
         for x, y in zip(xs, ys):
@@ -195,21 +201,25 @@ def train_hybrid(train, test):
                 key, dk = jax.random.split(key)
                 d = hybrid_diagnostics(
                     model, loss_fn, loss_fn, dk, batch=(x, y),
-                    num_samples=K, sigma=SIGMA, lam=LAM,
+                    num_samples=K, sigma=SIGMA, lam=lam, normalize=normalize,
                 )
                 cosines.append(float(d["cosine"]))
                 orth_norms.append(float(d["g_orth_norm"]))
                 s_norms.append(float(d["g_s_norm"]))
+                fracs.append(float(d["correction_fraction"]))
     dt = time.perf_counter() - t0
     tl, ta = evaluate(model, test)
     return {
         "true_loss": tl,
         "acc": ta,
         "train_s": dt,
+        "normalize": normalize,
+        "lam": lam,
         "diag": {
             "mean_cosine_es_vs_surrogate": float(np.mean(cosines)) if cosines else None,
             "mean_g_orth_norm": float(np.mean(orth_norms)) if orth_norms else None,
             "mean_g_s_norm": float(np.mean(s_norms)) if s_norms else None,
+            "mean_correction_fraction": float(np.mean(fracs)) if fracs else None,
         },
     }
 
@@ -219,7 +229,7 @@ def main():
     print(
         f"backend={jax.default_backend()}  SMOKE={SMOKE}  "
         f"C={CHANNELS} H={HIDDEN} classes={N_CLASSES} T={SAMPLE_T}  "
-        f"epochs={EPOCHS} K={K} sigma={SIGMA} lam={LAM}",
+        f"epochs={EPOCHS} K={K} sigma={SIGMA} lam={LAM} lam_norm={LAM_NORM}",
         flush=True,
     )
     train, test = synthetic_data()
@@ -241,35 +251,48 @@ def main():
         flush=True,
     )
 
-    print("== 3. hybrid ==", flush=True)
-    r_hy = train_hybrid(train, test)
-    print(
-        f"  true_loss={r_hy['true_loss']:.4f}  acc={r_hy['acc'] * 100:.2f}%  "
-        f"({r_hy['train_s']:.2f}s)",
-        flush=True,
-    )
+    print("== 3. hybrid (raw lam) ==", flush=True)
+    r_hy = train_hybrid(train, test, normalize=False, lam=LAM)
     d = r_hy["diag"]
     print(
-        f"  diagnostics: mean cosine(g_es,g_s)={d['mean_cosine_es_vs_surrogate']}  "
-        f"mean ||g_orth||={d['mean_g_orth_norm']}  mean ||g_s||={d['mean_g_s_norm']}",
+        f"  true_loss={r_hy['true_loss']:.4f}  acc={r_hy['acc'] * 100:.2f}%  "
+        f"({r_hy['train_s']:.2f}s)  "
+        f"mean ||g_orth||/||g_s||="
+        f"{d['mean_g_orth_norm'] / d['mean_g_s_norm']:.2f}  "
+        f"correction_frac={d['mean_correction_fraction']:.2f}",
         flush=True,
     )
 
-    print("\n== three-arm comparison (final TRUE loss / accuracy) ==", flush=True)
-    rows = [("surrogate", r_sur), ("es", r_es), ("hybrid", r_hy)]
-    print(f"  {'arm':<10} {'true_loss':>10} {'accuracy':>10} {'train_s':>9}")
+    print("== 4. hybrid (normalized lam) ==", flush=True)
+    r_hyn = train_hybrid(train, test, normalize=True, lam=LAM_NORM)
+    dn = r_hyn["diag"]
+    print(
+        f"  true_loss={r_hyn['true_loss']:.4f}  acc={r_hyn['acc'] * 100:.2f}%  "
+        f"({r_hyn['train_s']:.2f}s)  "
+        f"correction_frac={dn['mean_correction_fraction']:.2f} (== lam_norm)",
+        flush=True,
+    )
+
+    print("\n== four-arm comparison (final TRUE loss / accuracy) ==", flush=True)
+    rows = [
+        ("surrogate", r_sur),
+        ("es", r_es),
+        ("hybrid-raw", r_hy),
+        ("hybrid-norm", r_hyn),
+    ]
+    print(f"  {'arm':<12} {'true_loss':>10} {'accuracy':>10} {'train_s':>9}")
     for name, r in rows:
         print(
-            f"  {name:<10} {r['true_loss']:>10.4f} "
+            f"  {name:<12} {r['true_loss']:>10.4f} "
             f"{r['acc'] * 100:>9.2f}% {r['train_s']:>9.2f}"
         )
 
     best = min(rows, key=lambda kv: kv[1]["true_loss"])[0]
+    delta = r_hyn["true_loss"] - r_sur["true_loss"]
     print(f"\n  lowest true loss: {best}", flush=True)
     print(
-        "  (honest note: in the smoke regime pure-ES trails and the ES "
-        "correction can exceed ||g_s|| in magnitude, dragging hybrid below the "
-        "surrogate unless lam is scaled down; see README.)",
+        f"  hybrid-norm − surrogate true_loss = {delta:+.4f} "
+        f"({'hybrid-norm wins' if delta < 0 else 'surrogate wins'})",
         flush=True,
     )
 
@@ -284,11 +307,18 @@ def main():
             "num_samples_K": K,
             "sigma": SIGMA,
             "lam": LAM,
+            "lam_norm": LAM_NORM,
             "lr": LR,
             "seed": SEED,
         },
-        "results": {"surrogate": r_sur, "es": r_es, "hybrid": r_hy},
+        "results": {
+            "surrogate": r_sur,
+            "es": r_es,
+            "hybrid_raw": r_hy,
+            "hybrid_norm": r_hyn,
+        },
         "lowest_true_loss_arm": best,
+        "hybrid_norm_minus_surrogate": delta,
     }
     here = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(here, "study_results.json"), "w") as f:

--- a/research/new/hybrid_evo_surrogate/study_results.json
+++ b/research/new/hybrid_evo_surrogate/study_results.json
@@ -9,6 +9,7 @@
     "num_samples_K": 16,
     "sigma": 0.02,
     "lam": 0.5,
+    "lam_norm": 0.3,
     "lr": 0.005,
     "seed": 0
   },
@@ -16,23 +17,40 @@
     "surrogate": {
       "true_loss": 1.4665851593017578,
       "acc": 0.3333333432674408,
-      "train_s": 0.4818916039985197
+      "train_s": 0.4320368469998357
     },
     "es": {
       "true_loss": 2.683535099029541,
       "acc": 0.25,
-      "train_s": 3.0998199909990944
+      "train_s": 2.9637580330017954
     },
-    "hybrid": {
+    "hybrid_raw": {
       "true_loss": 2.5337307453155518,
       "acc": 0.25,
-      "train_s": 6.08069483899817,
+      "train_s": 6.0417883720001555,
+      "normalize": false,
+      "lam": 0.5,
       "diag": {
         "mean_cosine_es_vs_surrogate": 0.28151483833789825,
         "mean_g_orth_norm": 41.257680892944336,
-        "mean_g_s_norm": 8.57182502746582
+        "mean_g_s_norm": 8.57182502746582,
+        "mean_correction_fraction": 2.5755189657211304
+      }
+    },
+    "hybrid_norm": {
+      "true_loss": 1.9268078804016113,
+      "acc": 0.3333333432674408,
+      "train_s": 5.7739303529997414,
+      "normalize": true,
+      "lam": 0.3,
+      "diag": {
+        "mean_cosine_es_vs_surrogate": 0.2818133756518364,
+        "mean_g_orth_norm": 41.34477615356445,
+        "mean_g_s_norm": 7.498959541320801,
+        "mean_correction_fraction": 0.30000001192092896
       }
     }
   },
-  "lowest_true_loss_arm": "surrogate"
+  "lowest_true_loss_arm": "surrogate",
+  "hybrid_norm_minus_surrogate": 0.4602227210998535
 }

--- a/research/new/hybrid_evo_surrogate/study_results.json
+++ b/research/new/hybrid_evo_surrogate/study_results.json
@@ -1,0 +1,38 @@
+{
+  "config": {
+    "smoke": true,
+    "channels": 12,
+    "hidden": 12,
+    "n_classes": 3,
+    "sample_T": 8,
+    "epochs": 8,
+    "num_samples_K": 16,
+    "sigma": 0.02,
+    "lam": 0.5,
+    "lr": 0.005,
+    "seed": 0
+  },
+  "results": {
+    "surrogate": {
+      "true_loss": 1.4665851593017578,
+      "acc": 0.3333333432674408,
+      "train_s": 0.4818916039985197
+    },
+    "es": {
+      "true_loss": 2.683535099029541,
+      "acc": 0.25,
+      "train_s": 3.0998199909990944
+    },
+    "hybrid": {
+      "true_loss": 2.5337307453155518,
+      "acc": 0.25,
+      "train_s": 6.08069483899817,
+      "diag": {
+        "mean_cosine_es_vs_surrogate": 0.28151483833789825,
+        "mean_g_orth_norm": 41.257680892944336,
+        "mean_g_s_norm": 8.57182502746582
+      }
+    }
+  },
+  "lowest_true_loss_arm": "surrogate"
+}

--- a/research/new/hybrid_evo_surrogate/sweep.py
+++ b/research/new/hybrid_evo_surrogate/sweep.py
@@ -1,0 +1,237 @@
+"""Sweep: does the self-normalising orthogonal-ES correction beat pure surrogate?
+
+``run.py`` is a single-config three/four-arm demo. This sweep answers the harder
+question the PR #49 study left open: across seeds, ES sample counts ``K`` and
+correction fractions ``λ``, does ``hybrid-norm`` (surrogate + self-normalised
+orthogonal-ES correction) reach a *lower true loss* than pure surrogate descent,
+and is the effect robust to seed noise or just a fluke?
+
+Design (held fixed across arms within a config): same init, optimizer, data, step
+budget; arms differ only in how the gradient is built. We compare three arms per
+config — ``surrogate``, ``hybrid-raw`` (fixed raw ``λ=0.5``, the PR #49 setting),
+and ``hybrid-norm`` (self-normalised ``λ`` = correction fraction). Pure-ES is
+omitted; PR #49 already established it trails.
+
+Regime is deliberately harder/noisier than ``run.py``'s SMOKE path (more surrogate
+bias for ES to correct) but still CPU-cheap. Runs multiple seeds per cell and
+reports the mean Δ(true_loss) = hybrid-norm − surrogate with its spread, so a win
+has to survive seed noise. Writes ``sweep_results.json``.
+
+Run::
+
+    uv run python research/new/hybrid_evo_surrogate/sweep.py            # full grid
+    SEEDS=0,1 KS=48 LAMS=0.3 uv run python .../sweep.py                 # quick
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from flax import nnx
+
+import spyx.axn as axn
+import spyx.fn as fn
+import spyx.nn as snn
+from spyx.experimental.hybrid import make_hybrid_train_step
+
+# Moderately hard regime: enough surrogate bias to leave room for a correction.
+CHANNELS, HIDDEN, N_CLASSES, SAMPLE_T = 24, 32, 4, 16
+N_TRAIN, N_TEST, BATCH = 128, 128, 32
+EPOCHS = int(os.environ.get("EPOCHS", "20"))
+SIGMA = float(os.environ.get("SIGMA", "0.02"))
+LR = float(os.environ.get("LR", "5e-3"))
+LAM_RAW = float(os.environ.get("LAM_RAW", "0.5"))
+
+SEEDS = [int(s) for s in os.environ.get("SEEDS", "0,1,2").split(",")]
+KS = [int(k) for k in os.environ.get("KS", "32,96").split(",")]
+LAMS = [float(x) for x in os.environ.get("LAMS", "0.15,0.3,0.5").split(",")]
+
+ce = fn.integral_crossentropy(smoothing=0.2)
+acc_fn = fn.integral_accuracy()
+
+
+def synthetic_data(seed):
+    """Class-conditional band-rate spikes, time-major (T, B, C) for spyx.nn.run."""
+    rng = np.random.default_rng(seed)
+    band = max(1, CHANNELS // N_CLASSES)
+
+    def make(n):
+        labels = rng.integers(0, N_CLASSES, size=n)
+        x = (rng.random((n, SAMPLE_T, CHANNELS)) < 0.05).astype(np.float32)
+        for i in range(n):
+            lo = labels[i] * band
+            x[i, :, lo : lo + band] += (rng.random((SAMPLE_T, band)) < 0.30).astype(
+                np.float32
+            )
+        return np.clip(x, 0.0, 1.0), labels.astype(np.int32)
+
+    def batched(x, y):
+        obs, lab = [], []
+        for s in range(0, x.shape[0] - BATCH + 1, BATCH):
+            obs.append(jnp.transpose(jnp.asarray(x[s : s + BATCH]), (1, 0, 2)))
+            lab.append(jnp.asarray(y[s : s + BATCH]))
+        return obs, lab
+
+    xtr, ytr = make(N_TRAIN)
+    xte, yte = make(N_TEST)
+    return batched(xtr, ytr), batched(xte, yte)
+
+
+class SpikingClassifier(nnx.Module):
+    def __init__(self, *, rngs):
+        self.net = snn.Sequential(
+            nnx.Linear(CHANNELS, HIDDEN, rngs=rngs),
+            snn.LIF((HIDDEN,), activation=axn.superspike(), rngs=rngs),
+            nnx.Linear(HIDDEN, N_CLASSES, rngs=rngs),
+            snn.LI((N_CLASSES,), rngs=rngs),
+        )
+
+    def __call__(self, x_TBC):
+        traces, _ = snn.run(self.net, x_TBC)
+        return jnp.transpose(traces, (1, 0, 2))
+
+
+def loss_fn(model, xb, yb):
+    return ce(model(xb), yb)
+
+
+def evaluate(model, test):
+    xs, ys = test
+    losses = jnp.stack([loss_fn(model, x, y) for x, y in zip(xs, ys, strict=True)])
+    accs = jnp.stack([acc_fn(model(x), y)[0] for x, y in zip(xs, ys, strict=True)])
+    return float(jnp.mean(losses)), float(jnp.mean(accs))
+
+
+def train_surrogate(train, test, seed):
+    model = SpikingClassifier(rngs=nnx.Rngs(seed))
+    opt = nnx.Optimizer(model, optax.adam(LR), wrt=nnx.Param)
+
+    @nnx.jit
+    def step(m, o, xb, yb):
+        loss, g = nnx.value_and_grad(lambda mm: loss_fn(mm, xb, yb))(m)
+        o.update(m, g)
+        return loss
+
+    xs, ys = train
+    for _ in range(EPOCHS):
+        for x, y in zip(xs, ys, strict=True):
+            step(model, opt, x, y)
+    return evaluate(model, test)
+
+
+def train_hybrid(train, test, seed, *, k, lam, normalize):
+    model = SpikingClassifier(rngs=nnx.Rngs(seed))
+    opt = nnx.Optimizer(model, optax.adam(LR), wrt=nnx.Param)
+    step = make_hybrid_train_step(
+        loss_fn, loss_fn, num_samples=k, sigma=SIGMA, lam=lam, normalize=normalize
+    )
+    xs, ys = train
+    key = jax.random.PRNGKey(seed)
+    for _ in range(EPOCHS):
+        for x, y in zip(xs, ys, strict=True):
+            key, sub = jax.random.split(key)
+            step(model, opt, sub, x, y)
+    return evaluate(model, test)
+
+
+def main():
+    print(
+        f"backend={jax.default_backend()}  regime C={CHANNELS} H={HIDDEN} "
+        f"classes={N_CLASSES} T={SAMPLE_T} epochs={EPOCHS}  "
+        f"seeds={SEEDS} Ks={KS} lams={LAMS} lam_raw={LAM_RAW}",
+        flush=True,
+    )
+    t0 = time.perf_counter()
+
+    # Surrogate + raw-hybrid depend only on seed (and K for raw); cache per seed.
+    sur = {}
+    raw = {}  # (seed, k) -> (loss, acc)
+    for seed in SEEDS:
+        train, test = synthetic_data(seed)
+        sur[seed] = train_surrogate(train, test, seed)
+        print(f"  seed={seed} surrogate  loss={sur[seed][0]:.4f}", flush=True)
+
+    cells = []  # one per (k, lam): aggregated over seeds
+    for k in KS:
+        # raw hybrid at fixed LAM_RAW for this K, per seed (the PR#49 failure mode).
+        for seed in SEEDS:
+            train, test = synthetic_data(seed)
+            raw[(seed, k)] = train_hybrid(
+                train, test, seed, k=k, lam=LAM_RAW, normalize=False
+            )
+        for lam in LAMS:
+            deltas, norm_losses, norm_accs = [], [], []
+            for seed in SEEDS:
+                train, test = synthetic_data(seed)
+                nl, na = train_hybrid(
+                    train, test, seed, k=k, lam=lam, normalize=True
+                )
+                norm_losses.append(nl)
+                norm_accs.append(na)
+                deltas.append(nl - sur[seed][0])
+            cell = {
+                "k": k,
+                "lam_norm": lam,
+                "mean_surrogate_loss": float(np.mean([sur[s][0] for s in SEEDS])),
+                "mean_hybrid_norm_loss": float(np.mean(norm_losses)),
+                "mean_hybrid_raw_loss": float(
+                    np.mean([raw[(s, k)][0] for s in SEEDS])
+                ),
+                "mean_delta_norm_minus_sur": float(np.mean(deltas)),
+                "std_delta": float(np.std(deltas)),
+                "wins": int(sum(1 for d in deltas if d < 0)),
+                "n_seeds": len(SEEDS),
+                "mean_hybrid_norm_acc": float(np.mean(norm_accs)),
+            }
+            cells.append(cell)
+            print(
+                f"  K={k:>3} lam={lam:<4}  "
+                f"sur={cell['mean_surrogate_loss']:.4f}  "
+                f"hyb-norm={cell['mean_hybrid_norm_loss']:.4f}  "
+                f"hyb-raw={cell['mean_hybrid_raw_loss']:.4f}  "
+                f"Δ={cell['mean_delta_norm_minus_sur']:+.4f}"
+                f"±{cell['std_delta']:.4f}  wins={cell['wins']}/{cell['n_seeds']}",
+                flush=True,
+            )
+
+    best = min(cells, key=lambda c: c["mean_delta_norm_minus_sur"])
+    dt = time.perf_counter() - t0
+    print(
+        f"\nbest cell: K={best['k']} lam={best['lam_norm']}  "
+        f"Δ={best['mean_delta_norm_minus_sur']:+.4f}±{best['std_delta']:.4f}  "
+        f"wins={best['wins']}/{best['n_seeds']}   ({dt:.1f}s total)",
+        flush=True,
+    )
+    verdict = (
+        "hybrid-norm beats surrogate"
+        if best["mean_delta_norm_minus_sur"] < 0 and best["wins"] > best["n_seeds"] // 2
+        else "surrogate still wins / not robust"
+    )
+    print(f"verdict: {verdict}", flush=True)
+
+    out = {
+        "regime": {
+            "channels": CHANNELS, "hidden": HIDDEN, "n_classes": N_CLASSES,
+            "sample_T": SAMPLE_T, "epochs": EPOCHS, "sigma": SIGMA, "lr": LR,
+            "lam_raw": LAM_RAW, "seeds": SEEDS, "Ks": KS, "lams": LAMS,
+        },
+        "surrogate_per_seed": {str(s): sur[s][0] for s in SEEDS},
+        "cells": cells,
+        "best_cell": best,
+        "verdict": verdict,
+        "wall_s": dt,
+    }
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "sweep_results.json"), "w") as f:
+        json.dump(out, f, indent=2)
+    print("wrote sweep_results.json", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spyx/experimental/__init__.py
+++ b/src/spyx/experimental/__init__.py
@@ -23,6 +23,13 @@ Contents:
 - :mod:`spyx.experimental.stochastic` — stochastic (Bernoulli-spiking) and
   parallelizable prototypes: ``SPSN``, ``StochasticAssociativeLIF``,
   ``StochasticAssociativeCuBaLIF`` and the ``sigmoid_bernoulli`` activations.
+- :mod:`spyx.experimental.hybrid` — the 0+1 hybrid trainer: a surrogate
+  gradient corrected by an antithetic-NES estimate of the true (hard-spike)
+  loss, projected orthogonal to the surrogate (``hybrid_gradient``,
+  ``make_hybrid_train_step``, ``es_gradient``, ``hybrid_diagnostics``).
+- :mod:`spyx.experimental.zoo` — runnable reference recipes keyed by
+  application (control / classification / language) and tagged by training
+  method × architecture (``REGISTRY``, ``list_recipes``, ``get``).
 
 Related research studies live under ``research/new/`` in the repository.
 """
@@ -31,8 +38,14 @@ Related research studies live under ``research/new/`` in the repository.
 # here so the experimental surface is discoverable in one place.
 from ..nn import PSU_LIF
 from ..phasor import ResonateFire
-from . import compress, raven, stochastic
+from . import compress, hybrid, raven, stochastic, zoo
 from .compress import pack_spikes, packed_spike_dense, unpack_spikes
+from .hybrid import (
+    es_gradient,
+    hybrid_diagnostics,
+    hybrid_gradient,
+    make_hybrid_train_step,
+)
 from .raven import RavenRSM, SlotRouter, SpikingSlotMemory, make_recall_batch
 from .stochastic import (
     SPSN,
@@ -44,8 +57,10 @@ from .stochastic import (
 
 __all__ = [
     "compress",
+    "hybrid",
     "raven",
     "stochastic",
+    "zoo",
     "PSU_LIF",
     "ResonateFire",
     "RavenRSM",
@@ -60,4 +75,8 @@ __all__ = [
     "StochasticAssociativeCuBaLIF",
     "sigmoid_bernoulli",
     "refractory_sigmoid_bernoulli",
+    "hybrid_gradient",
+    "make_hybrid_train_step",
+    "es_gradient",
+    "hybrid_diagnostics",
 ]

--- a/src/spyx/experimental/hybrid.py
+++ b/src/spyx/experimental/hybrid.py
@@ -45,6 +45,18 @@ complement of **Guided-ES** (Maheswaranathan et al. 2019), which restricts the
 ES *search* to the surrogate's subspace; here we restrict it to the orthogonal
 complement and add it as an error-correction term.
 
+Self-normalising ``λ``
+----------------------
+With a *raw* ``λ`` the correction magnitude ``λ·‖g_orth‖`` depends on the ES
+smoothing ``σ`` and sample count ``K`` — when ``‖g_orth‖ ≫ ‖g_s‖`` (common with a
+high-variance estimate) even a modest ``λ`` lets the correction swamp the bulk
+direction and *hurt*. Passing ``normalize=True`` reinterprets ``λ`` as a
+dimensionless **fraction of the surrogate step**: the correction is rescaled by
+``λ · ‖g_s‖ / ‖g_orth‖`` so that ``‖applied correction‖ = λ · ‖g_s‖`` exactly,
+regardless of the ES scale. ``λ = 0.2`` then means "nudge the surrogate step by at
+most 20 % in the direction it is blind to," which transfers across regimes and
+keeps the ES term from ever dominating.
+
 All the linear algebra happens on the flat parameter vector via
 :func:`jax.flatten_util.ravel_pytree`, and perturbations are applied by
 ``nnx.split`` → perturb-flat → ``nnx.merge``, so the machinery is agnostic to
@@ -145,6 +157,7 @@ def _hybrid_flat(
     sigma: float,
     lam: float,
     eps: float,
+    normalize: bool,
 ):
     """Core routine: returns ``(unravel, g_flat, diagnostics)`` on the flat vector.
 
@@ -168,17 +181,30 @@ def _hybrid_flat(
     g_s_hat = g_s / (g_s_norm + eps)
     proj = jnp.dot(g_es, g_s_hat)
     g_orth = g_es - proj * g_s_hat
-    # 4. Corrected gradient: bulk surrogate + orthogonal ES correction.
-    g = g_s + lam * g_orth
+    # 4. Effective correction weight. In ``normalize`` mode ``lam`` is a
+    #    dimensionless *fraction of the surrogate step*: the correction is rescaled
+    #    so ``‖lam_eff · g_orth‖ = lam · ‖g_s‖`` regardless of the ES variance /
+    #    smoothing scale. This is the self-normalising ``λ · ‖g_s‖ / ‖g_orth‖`` that
+    #    keeps the high-variance ES term from ever dominating the bulk direction
+    #    (the failure mode when ‖g_orth‖ ≫ ‖g_s‖ at a fixed raw ``lam``).
+    g_orth_norm = jnp.linalg.norm(g_orth)
+    lam_eff = jnp.where(
+        normalize, lam * g_s_norm / (g_orth_norm + eps), jnp.asarray(lam, theta.dtype)
+    )
+    # 5. Corrected gradient: bulk surrogate + orthogonal ES correction.
+    g = g_s + lam_eff * g_orth
 
     g_es_norm = jnp.linalg.norm(g_es)
     diagnostics = {
         # cosine ⟨g_es, ĝ_s⟩ / ‖g_es‖ : how aligned ES is with the surrogate.
         "cosine": jnp.dot(g_es, g_s) / (g_es_norm * g_s_norm + eps),
-        "g_orth_norm": jnp.linalg.norm(g_orth),  # magnitude of the correction
+        "g_orth_norm": g_orth_norm,  # magnitude of the raw correction
         "g_s_norm": g_s_norm,
         "g_es_norm": g_es_norm,
         "proj": proj,  # ⟨g_es, ĝ_s⟩
+        "lam_eff": lam_eff,  # weight actually applied to g_orth
+        # ‖applied correction‖ / ‖g_s‖ — in normalize mode this equals ``lam``.
+        "correction_fraction": lam_eff * g_orth_norm / (g_s_norm + eps),
         # Flat vectors, exposed for tests / research inspection.
         "g_s": g_s,
         "g_es": g_es,
@@ -198,6 +224,7 @@ def hybrid_gradient(
     sigma: float = 0.01,
     lam: float = 1.0,
     eps: float = 1e-8,
+    normalize: bool = False,
     return_diagnostics: bool = False,
 ):
     r"""Surrogate gradient corrected by orthogonalised evolutionary strategies.
@@ -221,11 +248,16 @@ def hybrid_gradient(
     :param num_samples: number ``K`` of antithetic perturbation pairs.
     :param sigma: ES perturbation scale ``σ``.
     :param lam: weight ``λ`` on the orthogonal ES correction. ``λ = 0`` recovers
-        pure surrogate descent.
+        pure surrogate descent. With ``normalize=True`` it is a dimensionless
+        *fraction of the surrogate step* rather than a raw scale.
     :param eps: numerical floor for the normalisation of ``g_s``.
+    :param normalize: if ``True``, self-normalise the correction so its magnitude
+        is exactly ``λ · ‖g_s‖`` — the ES term becomes a bounded fraction of the
+        surrogate step, immune to the ES variance/``σ`` scaling that otherwise lets
+        ``‖g_orth‖`` swamp ``‖g_s‖``. Recommended when tuning ``λ`` across regimes.
     :param return_diagnostics: if ``True`` also return the diagnostics dict from
-        :func:`hybrid_diagnostics` (``cosine``, ``g_orth_norm``, the flat vectors,
-        …).
+        :func:`hybrid_diagnostics` (``cosine``, ``g_orth_norm``, ``lam_eff``,
+        ``correction_fraction``, the flat vectors, …).
     :return: an ``nnx.State`` of grads, or ``(grads, diagnostics)`` if
         ``return_diagnostics``.
     """
@@ -239,6 +271,7 @@ def hybrid_gradient(
         sigma=sigma,
         lam=lam,
         eps=eps,
+        normalize=normalize,
     )
     grads = unravel(g)
     if return_diagnostics:
@@ -257,6 +290,7 @@ def hybrid_diagnostics(
     sigma: float = 0.01,
     lam: float = 1.0,
     eps: float = 1e-8,
+    normalize: bool = False,
 ) -> dict[str, jax.Array]:
     r"""Diagnostics for a hybrid step *without* applying it.
 
@@ -266,9 +300,13 @@ def hybrid_diagnostics(
       surrogate direction. Near ``±1`` means ES mostly re-derives the surrogate
       (little to correct); near ``0`` means ES points somewhere the surrogate is
       blind (the regime where hybrid should help).
-    - ``g_orth_norm`` — ``‖g_orth‖``: magnitude of the orthogonal correction.
+    - ``g_orth_norm`` — ``‖g_orth‖``: magnitude of the (raw) orthogonal correction.
     - ``g_s_norm`` / ``g_es_norm`` — the two source magnitudes.
     - ``proj`` — the scalar projection ``⟨g_es, ĝ_s⟩``.
+    - ``lam_eff`` — the weight actually applied to ``g_orth`` (equals ``lam`` unless
+      ``normalize``, where it is ``lam · ‖g_s‖ / ‖g_orth‖``).
+    - ``correction_fraction`` — ``‖lam_eff · g_orth‖ / ‖g_s‖`` (equals ``lam`` in
+      ``normalize`` mode); how big the applied correction is next to the surrogate.
     - ``g_s`` / ``g_es`` / ``g_orth`` — the flat vectors themselves.
 
     Same signature as :func:`hybrid_gradient` (minus ``return_diagnostics``).
@@ -283,6 +321,7 @@ def hybrid_diagnostics(
         sigma=sigma,
         lam=lam,
         eps=eps,
+        normalize=normalize,
     )
     return diagnostics
 
@@ -294,6 +333,7 @@ def make_hybrid_train_step(
     num_samples: int = 8,
     sigma: float = 0.01,
     lam: float = 1.0,
+    normalize: bool = False,
 ) -> Callable[..., jax.Array]:
     r"""Build a single-step hybrid updater.
 
@@ -308,6 +348,8 @@ def make_hybrid_train_step(
     :param num_samples: number ``K`` of antithetic perturbation pairs.
     :param sigma: ES perturbation scale ``σ``.
     :param lam: weight ``λ`` on the orthogonal ES correction.
+    :param normalize: self-normalise the correction to ``λ · ‖g_s‖`` (see
+        :func:`hybrid_gradient`).
     :return: ``step(model, optimizer, key, *batch) -> true_loss``.
     """
 
@@ -321,6 +363,7 @@ def make_hybrid_train_step(
             num_samples=num_samples,
             sigma=sigma,
             lam=lam,
+            normalize=normalize,
         )
         loss = loss_true(model, *batch)
         optimizer.update(model, grads)

--- a/src/spyx/experimental/hybrid.py
+++ b/src/spyx/experimental/hybrid.py
@@ -1,0 +1,337 @@
+r"""Hybrid surrogate-gradient / evolutionary training for spiking networks.
+
+.. note::
+   **Experimental.** Unstable API — may change without a deprecation cycle.
+   Import it as ``from spyx.experimental.hybrid import hybrid_gradient`` (the
+   :mod:`spyx.experimental.hybrid` submodule is importable without touching the
+   package ``__init__``).
+
+The idea
+--------
+Surrogate-gradient descent through a spiking network is *cheap* but *biased*:
+the true forward objective uses a hard Heaviside spike whose gradient is zero
+almost everywhere, so we substitute a smooth surrogate (``spyx.axn``) in the
+backward pass. The resulting direction descends a *related* landscape, not the
+true one, and the mismatch is a systematic bias.
+
+Evolutionary strategies (ES / NES) estimate the gradient of the **true**
+(hard-spike, non-differentiable) objective from forward evaluations alone, with
+no surrogate at all. Pure ES is unbiased but high-variance and slow to converge
+in high dimensions.
+
+``hybrid_gradient`` combines the two so that ES pays only for what the surrogate
+gets *wrong*:
+
+1. ``g_s  = ∇θ loss_surrogate(θ)`` — the cheap, biased bulk descent direction
+   (one ``jax.grad`` through the surrogate spikes).
+2. ``g_es`` — an **antithetic NES** estimate of the gradient of the true loss,
+   drawn over the *full flattened parameter vector*::
+
+       g_es = 1/(2 σ K) Σ_k [loss_true(θ + σ ε_k) − loss_true(θ − σ ε_k)] ε_k,
+       ε_k ~ N(0, I).
+
+3. **Global orthogonalisation** (over the whole flattened vector, not per-leaf).
+   Let ``ĝ_s = g_s / (‖g_s‖ + eps)``. Project the ES estimate onto the subspace
+   the surrogate does *not* already cover::
+
+       g_orth = g_es − ⟨g_es, ĝ_s⟩ ĝ_s.
+
+4. **Corrected gradient**: ``g = g_s + λ · g_orth``.
+
+The surrogate supplies the bulk direction; ES supplies *only* the correction in
+the subspace where the surrogate is blind (its bias). Orthogonalising avoids
+double-counting directions the surrogate already handles. This is the exact
+complement of **Guided-ES** (Maheswaranathan et al. 2019), which restricts the
+ES *search* to the surrogate's subspace; here we restrict it to the orthogonal
+complement and add it as an error-correction term.
+
+All the linear algebra happens on the flat parameter vector via
+:func:`jax.flatten_util.ravel_pytree`, and perturbations are applied by
+``nnx.split`` → perturb-flat → ``nnx.merge``, so the machinery is agnostic to
+the model's pytree structure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.flatten_util import ravel_pytree
+
+LossFn = Callable[..., jax.Array]
+"""``(model, *batch) -> scalar`` loss. Surrogate losses must be differentiable
+through the ``spyx.axn`` surrogate spikes; true losses need only be evaluable."""
+
+
+def _split_and_ravel(model: nnx.Module):
+    """Split ``model`` into (graphdef, flat params, unravel, rest).
+
+    ``rest`` holds every non-``Param`` piece of state, threaded through
+    :func:`nnx.merge` untouched so perturbations only ever hit the trainable
+    parameters. ``unravel`` maps a flat vector back to the ``Param`` ``nnx.State``
+    pytree so the result drops straight into ``optimizer.update(model, grads)``.
+    """
+    graphdef, params, rest = nnx.split(model, nnx.Param, ...)
+    theta, unravel = ravel_pytree(params)
+    return graphdef, theta, unravel, rest
+
+
+def _es_flat(
+    theta: jax.Array,
+    true_loss_flat: Callable[[jax.Array], jax.Array],
+    key: jax.Array,
+    *,
+    num_samples: int,
+    sigma: float,
+) -> jax.Array:
+    """Antithetic NES estimate of ∇ true-loss over the flat vector ``theta``.
+
+    Antithetic pairs share each ``ε_k`` (the ``+`` and ``−`` legs), which cancels
+    the even-order terms of the Taylor expansion and halves the variance versus a
+    one-sided estimate. For a locally quadratic loss this is *unbiased*.
+    """
+    eps = jax.random.normal(key, (num_samples,) + theta.shape, dtype=theta.dtype)
+    l_plus = jax.vmap(true_loss_flat)(theta[None] + sigma * eps)
+    l_minus = jax.vmap(true_loss_flat)(theta[None] - sigma * eps)
+    coeff = (l_plus - l_minus) / (2.0 * sigma * num_samples)  # (K,)
+    return coeff @ eps  # (D,)
+
+
+def es_gradient(
+    model: nnx.Module,
+    loss_true: LossFn,
+    key: jax.Array,
+    *,
+    batch: tuple[Any, ...] = (),
+    num_samples: int = 8,
+    sigma: float = 0.01,
+) -> nnx.State:
+    """Pure antithetic-NES gradient of the *true* loss as a param pytree.
+
+    Gradient-free: only forward evaluations of ``loss_true`` are used, so the
+    loss may be non-differentiable (hard Heaviside spikes, hard accuracy, …).
+    Returned grads match ``model``'s ``Param`` structure and drop into
+    ``optimizer.update(model, grads)``. This is the "pure ES" baseline arm; it is
+    also the term :func:`hybrid_gradient` orthogonalises against the surrogate.
+
+    :param model: the Spyx / Flax NNX module whose params are perturbed.
+    :param loss_true: ``(model, *batch) -> scalar`` true objective.
+    :param key: a ``jax.random.PRNGKey``; antithetic pairs share ``ε``.
+    :param batch: extra positional args forwarded to the loss (e.g. ``(x, y)``).
+    :param num_samples: number ``K`` of antithetic perturbation pairs.
+    :param sigma: perturbation scale ``σ`` (smoothing radius of the estimate).
+    :return: an ``nnx.State`` of gradients matching the model's ``Param`` pytree.
+    """
+    graphdef, theta, unravel, rest = _split_and_ravel(model)
+
+    def true_loss_flat(flat):
+        return loss_true(nnx.merge(graphdef, unravel(flat), rest), *batch)
+
+    g_es = _es_flat(theta, true_loss_flat, key, num_samples=num_samples, sigma=sigma)
+    return unravel(g_es)
+
+
+def _hybrid_flat(
+    model: nnx.Module,
+    loss_surrogate: LossFn,
+    loss_true: LossFn,
+    key: jax.Array,
+    *,
+    batch: tuple[Any, ...],
+    num_samples: int,
+    sigma: float,
+    lam: float,
+    eps: float,
+):
+    """Core routine: returns ``(unravel, g_flat, diagnostics)`` on the flat vector.
+
+    Split out so both :func:`hybrid_gradient` and :func:`hybrid_diagnostics` share
+    exactly one implementation of the projection algebra.
+    """
+    graphdef, theta, unravel, rest = _split_and_ravel(model)
+
+    def surrogate_loss_flat(flat):
+        return loss_surrogate(nnx.merge(graphdef, unravel(flat), rest), *batch)
+
+    def true_loss_flat(flat):
+        return loss_true(nnx.merge(graphdef, unravel(flat), rest), *batch)
+
+    # 1. Cheap biased bulk direction from the surrogate backward pass.
+    g_s = jax.grad(surrogate_loss_flat)(theta)
+    # 2. Antithetic NES estimate of the true-loss gradient.
+    g_es = _es_flat(theta, true_loss_flat, key, num_samples=num_samples, sigma=sigma)
+    # 3. Global orthogonalisation against the (normalised) surrogate direction.
+    g_s_norm = jnp.linalg.norm(g_s)
+    g_s_hat = g_s / (g_s_norm + eps)
+    proj = jnp.dot(g_es, g_s_hat)
+    g_orth = g_es - proj * g_s_hat
+    # 4. Corrected gradient: bulk surrogate + orthogonal ES correction.
+    g = g_s + lam * g_orth
+
+    g_es_norm = jnp.linalg.norm(g_es)
+    diagnostics = {
+        # cosine ⟨g_es, ĝ_s⟩ / ‖g_es‖ : how aligned ES is with the surrogate.
+        "cosine": jnp.dot(g_es, g_s) / (g_es_norm * g_s_norm + eps),
+        "g_orth_norm": jnp.linalg.norm(g_orth),  # magnitude of the correction
+        "g_s_norm": g_s_norm,
+        "g_es_norm": g_es_norm,
+        "proj": proj,  # ⟨g_es, ĝ_s⟩
+        # Flat vectors, exposed for tests / research inspection.
+        "g_s": g_s,
+        "g_es": g_es,
+        "g_orth": g_orth,
+    }
+    return unravel, g, diagnostics
+
+
+def hybrid_gradient(
+    model: nnx.Module,
+    loss_surrogate: LossFn,
+    loss_true: LossFn,
+    key: jax.Array,
+    *,
+    batch: tuple[Any, ...] = (),
+    num_samples: int = 8,
+    sigma: float = 0.01,
+    lam: float = 1.0,
+    eps: float = 1e-8,
+    return_diagnostics: bool = False,
+):
+    r"""Surrogate gradient corrected by orthogonalised evolutionary strategies.
+
+    Computes ``g = g_s + λ · g_orth`` (see the module docstring for the full
+    derivation), where ``g_s`` is the surrogate gradient and ``g_orth`` is the
+    antithetic-NES estimate of the *true* gradient with its surrogate-aligned
+    component projected out. The returned grads match ``model``'s ``Param``
+    pytree, so::
+
+        grads = hybrid_gradient(model, loss_surrogate, loss_true, key, batch=(x, y))
+        optimizer.update(model, grads)
+
+    :param model: the Spyx / Flax NNX module to differentiate.
+    :param loss_surrogate: differentiable ``(model, *batch) -> scalar`` (surrogate
+        spikes). Supplies the cheap biased bulk direction ``g_s``.
+    :param loss_true: ``(model, *batch) -> scalar`` true objective (may be
+        non-differentiable / hard-spike); evaluated only in the forward pass.
+    :param key: a ``jax.random.PRNGKey`` for the ES perturbations.
+    :param batch: extra positional args forwarded to both losses (e.g. ``(x, y)``).
+    :param num_samples: number ``K`` of antithetic perturbation pairs.
+    :param sigma: ES perturbation scale ``σ``.
+    :param lam: weight ``λ`` on the orthogonal ES correction. ``λ = 0`` recovers
+        pure surrogate descent.
+    :param eps: numerical floor for the normalisation of ``g_s``.
+    :param return_diagnostics: if ``True`` also return the diagnostics dict from
+        :func:`hybrid_diagnostics` (``cosine``, ``g_orth_norm``, the flat vectors,
+        …).
+    :return: an ``nnx.State`` of grads, or ``(grads, diagnostics)`` if
+        ``return_diagnostics``.
+    """
+    unravel, g, diagnostics = _hybrid_flat(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        batch=batch,
+        num_samples=num_samples,
+        sigma=sigma,
+        lam=lam,
+        eps=eps,
+    )
+    grads = unravel(g)
+    if return_diagnostics:
+        return grads, diagnostics
+    return grads
+
+
+def hybrid_diagnostics(
+    model: nnx.Module,
+    loss_surrogate: LossFn,
+    loss_true: LossFn,
+    key: jax.Array,
+    *,
+    batch: tuple[Any, ...] = (),
+    num_samples: int = 8,
+    sigma: float = 0.01,
+    lam: float = 1.0,
+    eps: float = 1e-8,
+) -> dict[str, jax.Array]:
+    r"""Diagnostics for a hybrid step *without* applying it.
+
+    Returns a dict describing the correction the ES term contributes:
+
+    - ``cosine`` — ``⟨g_es, ĝ_s⟩ / ‖g_es‖``: alignment of the ES estimate with the
+      surrogate direction. Near ``±1`` means ES mostly re-derives the surrogate
+      (little to correct); near ``0`` means ES points somewhere the surrogate is
+      blind (the regime where hybrid should help).
+    - ``g_orth_norm`` — ``‖g_orth‖``: magnitude of the orthogonal correction.
+    - ``g_s_norm`` / ``g_es_norm`` — the two source magnitudes.
+    - ``proj`` — the scalar projection ``⟨g_es, ĝ_s⟩``.
+    - ``g_s`` / ``g_es`` / ``g_orth`` — the flat vectors themselves.
+
+    Same signature as :func:`hybrid_gradient` (minus ``return_diagnostics``).
+    """
+    _, _, diagnostics = _hybrid_flat(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        batch=batch,
+        num_samples=num_samples,
+        sigma=sigma,
+        lam=lam,
+        eps=eps,
+    )
+    return diagnostics
+
+
+def make_hybrid_train_step(
+    loss_surrogate: LossFn,
+    loss_true: LossFn,
+    *,
+    num_samples: int = 8,
+    sigma: float = 0.01,
+    lam: float = 1.0,
+) -> Callable[..., jax.Array]:
+    r"""Build a single-step hybrid updater.
+
+    The returned callable has signature ``(model, optimizer, key, *batch) ->
+    true_loss`` and mutates ``model`` / ``optimizer`` in place via NNX, mirroring
+    :func:`spyx.optimize.make_train_step` but using :func:`hybrid_gradient` to
+    build the update. The scalar returned is ``loss_true`` evaluated at the
+    *pre-update* parameters (the objective the ES term actually targets).
+
+    :param loss_surrogate: differentiable ``(model, *batch) -> scalar``.
+    :param loss_true: ``(model, *batch) -> scalar`` true objective.
+    :param num_samples: number ``K`` of antithetic perturbation pairs.
+    :param sigma: ES perturbation scale ``σ``.
+    :param lam: weight ``λ`` on the orthogonal ES correction.
+    :return: ``step(model, optimizer, key, *batch) -> true_loss``.
+    """
+
+    def step(model, optimizer, key, *batch):
+        grads = hybrid_gradient(
+            model,
+            loss_surrogate,
+            loss_true,
+            key,
+            batch=tuple(batch),
+            num_samples=num_samples,
+            sigma=sigma,
+            lam=lam,
+        )
+        loss = loss_true(model, *batch)
+        optimizer.update(model, grads)
+        return loss
+
+    return step
+
+
+__all__ = [
+    "hybrid_gradient",
+    "hybrid_diagnostics",
+    "es_gradient",
+    "make_hybrid_train_step",
+]

--- a/src/spyx/experimental/zoo/__init__.py
+++ b/src/spyx/experimental/zoo/__init__.py
@@ -1,0 +1,127 @@
+"""The Spyx recipe **zoo** — runnable, synthetic-data SNN recipes.
+
+**Experimental.** This whole subpackage lives under
+:mod:`spyx.experimental`; its API may change without a deprecation cycle.
+
+Each recipe is a self-contained, download-free example of training a spiking /
+state-space model for one *application*, tagged by *method* × *architecture*:
+
+============== ============== ============= ==============
+application    method         architecture module
+============== ============== ============= ==============
+control        evolutionary   LIF-MLP       :mod:`.control`
+classification surrogate      RSNN          :mod:`.classification`
+language       surrogate      S5            :mod:`.language`
+============== ============== ============= ==============
+
+Every recipe exposes the same small surface via a :class:`Recipe` record:
+
+* ``build(rngs) -> nnx.Module`` — construct the model.
+* ``synthetic_batch(...) -> tuple`` — sample a download-free batch.
+* ``loss(model, *batch) -> scalar`` — a finite objective on that batch.
+* ``demo(steps=...) -> list[float]`` — run a few train/evolve steps and return
+  the fitness/loss history.
+
+The zoo is importable as its own subpackage — ``from spyx.experimental.zoo
+import REGISTRY, list_recipes, get`` — without touching
+``spyx.experimental.__init__``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from flax import nnx
+
+from . import classification, control, language
+
+
+@dataclass(frozen=True)
+class Recipe:
+    """A single runnable recipe, keyed by application and tagged by method × arch.
+
+    :name: unique registry key.
+    :application: one of ``'control'``, ``'classification'``, ``'language'``.
+    :method: training method, e.g. ``'evolutionary'``, ``'surrogate'``,
+        ``'conversion'``, ``'hybrid'``.
+    :architecture: model family, e.g. ``'LIF-MLP'``, ``'RSNN'``, ``'S5'``.
+    :build: ``(nnx.Rngs) -> nnx.Module`` model constructor.
+    :synthetic_batch: ``(...) -> tuple`` download-free batch sampler; the tuple
+        is splatted into ``loss`` after the model.
+    :describe: one-line human-readable description.
+    :loss: ``(model, *batch) -> scalar`` finite objective (fitness for
+        evolutionary recipes, training loss for gradient recipes).
+    :demo: ``(steps=...) -> list[float]`` short run returning a fitness/loss
+        history.
+    """
+
+    name: str
+    application: str
+    method: str
+    architecture: str
+    build: Callable[[nnx.Rngs], nnx.Module]
+    synthetic_batch: Callable[..., tuple]
+    describe: str
+    loss: Callable[..., object]
+    demo: Callable[..., list[float]]
+
+
+def _recipe_from_module(module) -> Recipe:
+    """Assemble a :class:`Recipe` from a recipe module's module-level surface."""
+    return Recipe(
+        name=module.NAME,
+        application=module.APPLICATION,
+        method=module.METHOD,
+        architecture=module.ARCHITECTURE,
+        build=module.build,
+        synthetic_batch=module.synthetic_batch,
+        describe=module.DESCRIBE,
+        loss=module.loss,
+        demo=module.demo,
+    )
+
+
+REGISTRY: dict[str, Recipe] = {
+    recipe.name: recipe
+    for recipe in (
+        _recipe_from_module(control),
+        _recipe_from_module(classification),
+        _recipe_from_module(language),
+    )
+}
+
+
+def list_recipes(
+    application: str | None = None, method: str | None = None
+) -> list[Recipe]:
+    """Return recipes, optionally filtered by ``application`` and/or ``method``.
+
+    :application: keep only recipes with this application (``None`` = any).
+    :method: keep only recipes with this method (``None`` = any).
+    :return: list of matching :class:`Recipe` records.
+    """
+    return [
+        recipe
+        for recipe in REGISTRY.values()
+        if (application is None or recipe.application == application)
+        and (method is None or recipe.method == method)
+    ]
+
+
+def get(name: str) -> Recipe:
+    """Look up a recipe by name, raising ``KeyError`` with the valid keys."""
+    if name not in REGISTRY:
+        raise KeyError(f"unknown recipe {name!r}; available: {sorted(REGISTRY)}")
+    return REGISTRY[name]
+
+
+__all__ = [
+    "Recipe",
+    "REGISTRY",
+    "list_recipes",
+    "get",
+    "control",
+    "classification",
+    "language",
+]

--- a/src/spyx/experimental/zoo/classification.py
+++ b/src/spyx/experimental/zoo/classification.py
@@ -1,0 +1,111 @@
+"""Classification recipe: a surrogate-trained recurrent SNN on temporal spikes.
+
+**Experimental.** Part of :mod:`spyx.experimental.zoo`; the API may change
+without a deprecation cycle.
+
+A small recurrent spiking network (``RSNN``: a recurrent LIF hidden layer)
+classifies SHD-shaped synthetic spike trains of shape ``[T=16, B, inputs=8]``
+into ``classes=4``. Each class activates a distinct pair of input channels at a
+higher firing rate, so the temporal signal is learnable. Training is by
+surrogate gradient: the recurrent layer uses an :mod:`spyx.axn` arctangent
+surrogate, sequences run through :func:`spyx.nn.run`, and the readout is scored
+with :func:`spyx.fn.integral_crossentropy`.
+
+Synthetic data only, no downloads; a handful of steps runs in well under a
+second on CPU.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from ... import axn, fn, optimize
+from ... import nn as snn
+
+NAME = "classification-rsnn"
+APPLICATION = "classification"
+METHOD = "surrogate"
+ARCHITECTURE = "RSNN"
+DESCRIBE = (
+    "Recurrent spiking network (recurrent LIF) classifying SHD-shaped synthetic "
+    "spike trains into 4 classes, trained by surrogate gradient via spyx.axn / "
+    "spyx.optimize."
+)
+
+TIME = 16
+INPUTS = 8
+HIDDEN = 24
+CLASSES = 4
+
+
+def build(rngs: nnx.Rngs) -> nnx.Module:
+    """Build the RSNN as a :class:`spyx.nn.Sequential`.
+
+    ``inputs -> Linear -> RLIF (recurrent, arctan surrogate) -> Linear -> LI``.
+    The leaky-integrator readout accumulates evidence over time for
+    :func:`spyx.fn.integral_crossentropy`.
+    """
+    return snn.Sequential(
+        nnx.Linear(INPUTS, HIDDEN, rngs=rngs),
+        snn.RLIF((HIDDEN,), activation=axn.arctan(), rngs=rngs),
+        nnx.Linear(HIDDEN, CLASSES, rngs=rngs),
+        snn.LI((CLASSES,), rngs=rngs),
+    )
+
+
+def synthetic_batch(key: jax.Array | None = None, batch_size: int = 32) -> tuple:
+    """Generate class-conditioned synthetic spike trains.
+
+    Each label ``c`` drives input channels ``2c`` and ``2c+1`` (mod ``INPUTS``)
+    at an elevated firing rate over a low background rate.
+
+    :return: ``(spikes, labels)`` with ``spikes`` of shape ``[T, B, INPUTS]``
+        (float 0/1) and integer ``labels`` of shape ``[B]``.
+    """
+    if key is None:
+        key = jax.random.PRNGKey(0)
+    k_label, k_spike = jax.random.split(key)
+    labels = jax.random.randint(k_label, (batch_size,), 0, CLASSES)
+
+    channels = jnp.stack([(labels * 2) % INPUTS, (labels * 2 + 1) % INPUTS], axis=-1)
+    active = jax.nn.one_hot(channels, INPUTS).sum(axis=1)  # (B, INPUTS)
+    rate = 0.1 + 0.6 * active[None]  # (1, B, INPUTS) broadcast over time
+    draws = jax.random.uniform(k_spike, (TIME, batch_size, INPUTS))
+    spikes = (draws < rate).astype(jnp.float32)
+    return spikes, labels
+
+
+# Loss closure over the SNN readout; scored across the (time-major) trace.
+_loss_fn = fn.integral_crossentropy(time_axis=0)
+
+
+def loss(model: nnx.Module, spikes: jax.Array, labels: jax.Array) -> jax.Array:
+    """Integral cross-entropy of the SNN readout on a synthetic batch."""
+    traces, _ = snn.run(model, spikes)
+    return _loss_fn(traces, labels)
+
+
+def demo(steps: int = 40, *, seed: int = 0, learning_rate: float = 2e-3) -> list[float]:
+    """Train a handful of surrogate-gradient steps and return the loss history.
+
+    :steps: number of gradient steps.
+    :seed: PRNG seed for model init and data.
+    :learning_rate: Adam learning rate.
+    :return: list of per-step training losses (should decrease).
+    """
+    import optax  # lazy import; optax is a core dependency
+
+    key = jax.random.PRNGKey(seed)
+    k_model, k_data = jax.random.split(key)
+    model = build(nnx.Rngs(k_model))
+    spikes, labels = synthetic_batch(k_data)
+
+    optimizer = nnx.Optimizer(model, optax.adam(learning_rate), wrt=nnx.Param)
+    step = optimize.make_train_step(loss)
+
+    history: list[float] = []
+    for _ in range(steps):
+        history.append(float(step(model, optimizer, spikes, labels)))
+    return history

--- a/src/spyx/experimental/zoo/control.py
+++ b/src/spyx/experimental/zoo/control.py
@@ -1,0 +1,150 @@
+"""Control recipe: an evolution-trained spiking policy on a toy point-mass.
+
+**Experimental.** Part of :mod:`spyx.experimental.zoo`; the API may change
+without a deprecation cycle.
+
+A tiny leaky-integrate-and-fire MLP (``LIF-MLP``) acts as a closed-loop
+controller for a 1-D point mass ``(x, v)`` with dynamics
+
+    v <- v + dt * force
+    x <- x + dt * v
+
+where ``force`` is the policy's scalar readout at each step. The objective is
+to drive ``x`` to the origin, so the (minimised) cost is the accumulated
+``x**2`` over the rollout. The policy is trained by an evolution strategy
+(OpenAI-ES via :mod:`evosax`) rather than backprop: parameters are flattened
+to a single vector with :func:`jax.flatten_util.ravel_pytree`, the ES proposes
+a population of perturbations, and each candidate is scored by rolling out the
+closed loop. No gradients flow through the (non-differentiable) rollout.
+
+Everything runs on synthetic initial conditions with no downloads and is sized
+to finish well under a second on CPU.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.flatten_util
+import jax.numpy as jnp
+from flax import nnx
+
+from ... import nn as snn
+
+NAME = "control-lif-es"
+APPLICATION = "control"
+METHOD = "evolutionary"
+ARCHITECTURE = "LIF-MLP"
+DESCRIBE = (
+    "Spiking LIF-MLP policy for a 1-D point-mass reaching task, trained by "
+    "OpenAI-ES (evosax) on flattened parameters — no backprop through the "
+    "closed-loop rollout."
+)
+
+# Environment / rollout constants (kept tiny for a sub-second CPU smoke path).
+OBS_DIM = 2  # [position, velocity]
+HIDDEN = 8
+ACT_DIM = 1  # scalar force
+DT = 0.1
+ROLLOUT_STEPS = 20
+
+
+def build(rngs: nnx.Rngs) -> snn.Sequential:
+    """Build the spiking policy as a :class:`spyx.nn.Sequential`.
+
+    ``obs -> Linear -> LIF -> Linear -> LI`` where the leaky-integrator readout
+    provides a continuous scalar force. Drops into :func:`spyx.nn.run` and the
+    manual closed-loop scan in :func:`rollout_cost`.
+    """
+    return snn.Sequential(
+        nnx.Linear(OBS_DIM, HIDDEN, rngs=rngs),
+        snn.LIF((HIDDEN,), rngs=rngs),
+        nnx.Linear(HIDDEN, ACT_DIM, rngs=rngs),
+        snn.LI((ACT_DIM,), rngs=rngs),
+    )
+
+
+def synthetic_batch(key: jax.Array | None = None, batch_size: int = 16) -> tuple:
+    """Sample a batch of initial ``(position, velocity)`` states.
+
+    :return: a 1-tuple ``(init_states,)`` with ``init_states`` of shape
+        ``(batch_size, 2)`` — matching the ``(batch,) + args`` convention used
+        by the other recipes' ``loss`` callables.
+    """
+    if key is None:
+        key = jax.random.PRNGKey(0)
+    init_states = jax.random.uniform(
+        key, (batch_size, OBS_DIM), minval=-1.0, maxval=1.0
+    )
+    return (init_states,)
+
+
+def rollout_cost(model: snn.Sequential, init_states: jax.Array) -> jax.Array:
+    """Roll the closed loop and return the mean accumulated ``x**2`` cost.
+
+    :model: spiking policy from :func:`build`.
+    :init_states: ``(batch, 2)`` initial ``(x, v)`` states.
+    :return: scalar cost (lower is better) — the ES fitness to minimise.
+    """
+    batch = init_states.shape[0]
+    neuron_state = model.initial_state(batch)
+
+    def step(carry, _):
+        env, nstate = carry
+        action, nstate = model(env, nstate)
+        force = action[..., 0]
+        v = env[..., 1] + DT * force
+        x = env[..., 0] + DT * v
+        cost = x**2
+        return (jnp.stack([x, v], axis=-1), nstate), cost
+
+    (_, _), costs = jax.lax.scan(
+        step, (init_states, neuron_state), None, length=ROLLOUT_STEPS
+    )
+    return jnp.mean(jnp.sum(costs, axis=0))
+
+
+# ``loss`` in the Recipe sense: a finite scalar objective on a synthetic batch.
+loss = rollout_cost
+
+
+def demo(steps: int = 15, *, seed: int = 0, population_size: int = 24) -> list[float]:
+    """Run a few OpenAI-ES generations and return the mean-fitness history.
+
+    :steps: number of ES generations.
+    :seed: PRNG seed for reproducibility.
+    :population_size: ES population size per generation.
+    :return: list of per-generation mean rollout costs (lower is better).
+    """
+    import optax  # lazy: optax is a core dep but imported here to keep import light
+    from evosax.algorithms import Open_ES
+
+    key = jax.random.PRNGKey(seed)
+    key, k_model, k_batch = jax.random.split(key, 3)
+
+    model = build(nnx.Rngs(k_model))
+    graphdef, params = nnx.split(model, nnx.Param)
+    flat, unravel = jax.flatten_util.ravel_pytree(params)
+
+    (init_states,) = synthetic_batch(k_batch)
+
+    def fitness(flat_vec):
+        candidate = nnx.merge(graphdef, unravel(flat_vec))
+        return rollout_cost(candidate, init_states)
+
+    es = Open_ES(
+        population_size=population_size,
+        solution=jnp.zeros_like(flat),
+        optimizer=optax.adam(0.1),
+        std_schedule=optax.constant_schedule(0.3),
+    )
+    es_params = es.default_params
+    state = es.init(key, flat, es_params)
+
+    history: list[float] = []
+    for _ in range(steps):
+        key, k_ask, k_tell = jax.random.split(key, 3)
+        population, state = es.ask(k_ask, state, es_params)
+        fitnesses = jax.vmap(fitness)(population)
+        state, _ = es.tell(k_tell, population, fitnesses, state, es_params)
+        history.append(float(jnp.mean(fitnesses)))
+    return history

--- a/src/spyx/experimental/zoo/language.py
+++ b/src/spyx/experimental/zoo/language.py
@@ -1,0 +1,111 @@
+"""Language recipe: an SSM (S5) next-token model on a synthetic sequence.
+
+**Experimental.** Part of :mod:`spyx.experimental.zoo`; the API may change
+without a deprecation cycle.
+
+A tiny character/token language model built on :class:`spyx.ssm.S5Diag`
+predicts the next token in a synthetic repeating sequence (a cyclic
+``0, 1, ..., V-1`` pattern with a random per-sample phase). Tokens are
+embedded, run through the diagonal SSM over time, and read out to vocabulary
+logits; the model is trained by standard gradient descent (softmax
+cross-entropy on the shifted sequence). Because the sequence is fully periodic,
+the loss drops quickly.
+
+Synthetic data only, no downloads; a few steps run in well under a second on
+CPU.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from ... import optimize, ssm
+
+NAME = "language-s5"
+APPLICATION = "language"
+METHOD = "gradient"
+ARCHITECTURE = "S5"
+DESCRIBE = (
+    "Diagonal-SSM (S5Diag) next-token language model on a synthetic repeating "
+    "token sequence, trained by standard gradient descent."
+)
+
+VOCAB = 6
+D_MODEL = 16
+D_STATE = 16
+SEQ_LEN = 32
+
+
+class S5LanguageModel(nnx.Module):
+    """Embed → :class:`spyx.ssm.S5Diag` → linear readout next-token model.
+
+    ``__call__`` maps token ids ``(B, T)`` to logits ``(B, T, VOCAB)``. The SSM
+    core operates time-major ``(T, B, D_MODEL)`` internally.
+    """
+
+    def __init__(self, *, rngs: nnx.Rngs):
+        self.embed = nnx.Embed(VOCAB, D_MODEL, rngs=rngs)
+        self.ssm = ssm.S5Diag(D_MODEL, D_STATE, rngs=rngs)
+        self.readout = nnx.Linear(D_MODEL, VOCAB, rngs=rngs)
+
+    def __call__(self, tokens: jax.Array) -> jax.Array:
+        x = self.embed(tokens)  # (B, T, D_MODEL)
+        x = jnp.transpose(x, (1, 0, 2))  # (T, B, D_MODEL)
+        y = self.ssm(x)  # (T, B, D_MODEL)
+        logits = self.readout(y)  # (T, B, VOCAB)
+        return jnp.transpose(logits, (1, 0, 2))  # (B, T, VOCAB)
+
+
+def build(rngs: nnx.Rngs) -> nnx.Module:
+    """Build the S5-based language model."""
+    return S5LanguageModel(rngs=rngs)
+
+
+def synthetic_batch(key: jax.Array | None = None, batch_size: int = 16) -> tuple:
+    """Generate a batch of cyclic token sequences with random phase.
+
+    Each sequence is ``(phase + t) mod VOCAB`` for ``t = 0 .. SEQ_LEN-1``.
+
+    :return: a 1-tuple ``(tokens,)`` with ``tokens`` of shape ``[B, SEQ_LEN]``.
+    """
+    if key is None:
+        key = jax.random.PRNGKey(0)
+    phase = jax.random.randint(key, (batch_size, 1), 0, VOCAB)
+    tokens = (jnp.arange(SEQ_LEN)[None, :] + phase) % VOCAB
+    return (tokens,)
+
+
+def loss(model: nnx.Module, tokens: jax.Array) -> jax.Array:
+    """Next-token softmax cross-entropy over the shifted sequence."""
+    import optax  # lazy import; optax is a core dependency
+
+    logits = model(tokens)  # (B, T, VOCAB)
+    inputs = logits[:, :-1]
+    targets = tokens[:, 1:]
+    return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(inputs, targets))
+
+
+def demo(steps: int = 40, *, seed: int = 0, learning_rate: float = 5e-3) -> list[float]:
+    """Train a few gradient steps and return the next-token loss history.
+
+    :steps: number of gradient steps.
+    :seed: PRNG seed for model init and data.
+    :learning_rate: Adam learning rate.
+    :return: list of per-step training losses (should decrease).
+    """
+    import optax  # lazy import; optax is a core dependency
+
+    key = jax.random.PRNGKey(seed)
+    k_model, k_data = jax.random.split(key)
+    model = build(nnx.Rngs(k_model))
+    (tokens,) = synthetic_batch(k_data)
+
+    optimizer = nnx.Optimizer(model, optax.adam(learning_rate), wrt=nnx.Param)
+    step = optimize.make_train_step(loss)
+
+    history: list[float] = []
+    for _ in range(steps):
+        history.append(float(step(model, optimizer, tokens)))
+    return history

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -119,6 +119,76 @@ def test_orthogonality_and_lambda_zero():
     assert jnp.allclose(g1_flat, diag["g_s"] + diag["g_orth"], atol=1e-6)
 
 
+def test_normalize_bounds_correction_to_fraction_of_surrogate():
+    """normalize=True makes ‖applied correction‖ == λ·‖g_s‖ (and still ⟂ g_s)."""
+    key = jax.random.PRNGKey(7)
+    model = VecModel(jnp.linspace(-1.0, 1.0, 6))
+
+    def loss_surrogate(m, target):
+        return jnp.sum((m.w[...] - target) ** 2)
+
+    def loss_true(m, target):
+        return jnp.sum((m.w[...] + 0.5) ** 2 + 0.1 * m.w[...] ** 4)
+
+    target = jnp.zeros((6,))
+    lam = 0.3
+    kw = dict(batch=(target,), num_samples=256, sigma=0.02)
+
+    grads, diag = hybrid_gradient(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        lam=lam,
+        normalize=True,
+        return_diagnostics=True,
+        **kw,
+    )
+    g = jax.flatten_util.ravel_pytree(grads)[0]
+    g_s = diag["g_s"]
+    correction = g - g_s
+
+    # The applied correction has norm exactly λ·‖g_s‖ ...
+    assert jnp.allclose(
+        jnp.linalg.norm(correction), lam * jnp.linalg.norm(g_s), rtol=1e-4
+    )
+    # ... points along g_orth ...
+    assert jnp.allclose(correction, diag["lam_eff"] * diag["g_orth"], atol=1e-5)
+    # ... stays orthogonal to the surrogate ...
+    dot = float(jnp.dot(correction, g_s))
+    scale = float(jnp.linalg.norm(correction) * jnp.linalg.norm(g_s))
+    assert abs(dot) <= 1e-4 * (scale + 1.0)
+    # ... and the reported fraction equals λ.
+    assert jnp.allclose(diag["correction_fraction"], lam, rtol=1e-4)
+
+    # normalize=False leaves λ as a raw scale (correction == λ·g_orth).
+    _, diag_raw = hybrid_gradient(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        lam=lam,
+        normalize=False,
+        return_diagnostics=True,
+        **kw,
+    )
+    assert jnp.allclose(diag_raw["lam_eff"], lam, rtol=1e-6)
+
+    # λ = 0 still recovers pure surrogate even in normalize mode.
+    g0 = jax.flatten_util.ravel_pytree(
+        hybrid_gradient(
+            model,
+            loss_surrogate,
+            loss_true,
+            key,
+            lam=0.0,
+            normalize=True,
+            **kw,
+        )
+    )[0]
+    assert jnp.allclose(g0, g_s, atol=1e-6)
+
+
 def test_grads_match_param_pytree_and_finite(rngs):
     """Returned grads share the model's Param structure and are finite."""
     model = TinyClassifier(4, 8, 3, axn.superspike(), rngs=rngs)

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -1,0 +1,226 @@
+"""Tests for the hybrid surrogate/ES training method.
+
+Covers, per the algorithm in ``spyx.experimental.hybrid``:
+
+* the projection identity ``g_orth ⟂ g_s`` and ``g == g_s`` when ``λ = 0``;
+* returned grads match the model's ``Param`` pytree and are finite;
+* the antithetic-ES estimate correlates with a *known* analytic gradient on a
+  smooth quadratic (cosine > 0.5 with enough samples and small ``σ``);
+* one end-to-end hybrid step on a tiny spiking classifier keeps the TRUE loss
+  finite and does not blow it up.
+
+None of these download data, so no ``@pytest.mark.network``.
+"""
+
+import jax
+import jax.numpy as jnp
+import optax
+from flax import nnx
+
+import spyx.axn as axn
+import spyx.fn as fn
+import spyx.nn as snn
+from spyx.experimental.hybrid import (
+    es_gradient,
+    hybrid_diagnostics,
+    hybrid_gradient,
+    make_hybrid_train_step,
+)
+
+
+class VecModel(nnx.Module):
+    """Trivial model: a single flat ``nnx.Param`` vector ``w``.
+
+    Lets tests express the loss directly as a function of the flat parameter, so
+    the analytic gradient is known and the projection algebra is easy to check.
+    """
+
+    def __init__(self, w0):
+        self.w = nnx.Param(jnp.asarray(w0, dtype=jnp.float32))
+
+
+class TinyClassifier(nnx.Module):
+    """Minimal spiking classifier: Linear -> LIF -> Linear -> LI, time-major.
+
+    ``__call__`` takes ``(T, B, C)`` spikes and returns a ``(B, T, n_classes)``
+    logit trace, matching the ``spyx.fn.integral_*`` (sum-over-time) convention.
+    """
+
+    def __init__(self, in_dim, hidden, n_classes, activation, *, rngs):
+        self.enc = nnx.Linear(in_dim, hidden, rngs=rngs)
+        self.lif = snn.LIF((hidden,), activation=activation, rngs=rngs)
+        self.dec = nnx.Linear(hidden, n_classes, rngs=rngs)
+        self.li = snn.LI((n_classes,), rngs=rngs)
+        self.net = snn.Sequential(self.enc, self.lif, self.dec, self.li)
+
+    def __call__(self, x_TBC):
+        traces, _ = snn.run(self.net, x_TBC)  # (T, B, n_classes)
+        return jnp.transpose(traces, (1, 0, 2))  # (B, T, n_classes)
+
+
+def test_orthogonality_and_lambda_zero():
+    """g_orth ⟂ g_s, and λ=0 recovers pure surrogate descent."""
+    key = jax.random.PRNGKey(0)
+    model = VecModel(jnp.linspace(-1.0, 1.0, 6))
+
+    # Two genuinely different scalar objectives so g_s and g_es are not parallel.
+    def loss_surrogate(m, target):
+        return jnp.sum((m.w[...] - target) ** 2)
+
+    def loss_true(m, target):
+        # A different landscape (shifted + quartic) so ES points elsewhere.
+        return jnp.sum((m.w[...] + 0.5) ** 2 + 0.1 * m.w[...] ** 4)
+
+    target = jnp.zeros((6,))
+
+    _, diag = hybrid_gradient(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        batch=(target,),
+        num_samples=256,
+        sigma=0.02,
+        lam=1.0,
+        return_diagnostics=True,
+    )
+
+    # Global orthogonality: <g_orth, g_s> ~ 0 relative to the vector scales.
+    dot = float(jnp.dot(diag["g_orth"], diag["g_s"]))
+    scale = float(jnp.linalg.norm(diag["g_orth"]) * jnp.linalg.norm(diag["g_s"]))
+    assert abs(dot) <= 1e-5 * (scale + 1.0)
+
+    # λ = 0 must return exactly g_s.
+    grads0 = hybrid_gradient(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        batch=(target,),
+        num_samples=256,
+        sigma=0.02,
+        lam=0.0,
+    )
+    g0_flat = jax.flatten_util.ravel_pytree(grads0)[0]
+    assert jnp.allclose(g0_flat, diag["g_s"], atol=1e-6)
+
+    # λ = 1 must return exactly g_s + g_orth.
+    grads1 = hybrid_gradient(
+        model,
+        loss_surrogate,
+        loss_true,
+        key,
+        batch=(target,),
+        num_samples=256,
+        sigma=0.02,
+        lam=1.0,
+    )
+    g1_flat = jax.flatten_util.ravel_pytree(grads1)[0]
+    assert jnp.allclose(g1_flat, diag["g_s"] + diag["g_orth"], atol=1e-6)
+
+
+def test_grads_match_param_pytree_and_finite(rngs):
+    """Returned grads share the model's Param structure and are finite."""
+    model = TinyClassifier(4, 8, 3, axn.superspike(), rngs=rngs)
+    T, B, C = 5, 2, 4
+    x = (jax.random.uniform(jax.random.PRNGKey(1), (T, B, C)) < 0.3).astype(jnp.float32)
+    y = jnp.array([0, 2])
+
+    loss = fn.integral_crossentropy()
+
+    def loss_fn(m, xb, yb):
+        return loss(m(xb), yb)
+
+    grads = hybrid_gradient(
+        model,
+        loss_fn,
+        loss_fn,
+        jax.random.PRNGKey(2),
+        batch=(x, y),
+        num_samples=4,
+        sigma=0.01,
+        lam=1.0,
+    )
+
+    params = nnx.state(model, nnx.Param)
+    g_leaves = jax.tree_util.tree_leaves(grads)
+    p_leaves = jax.tree_util.tree_leaves(params)
+    # Same pytree structure as the params.
+    assert jax.tree_util.tree_structure(grads) == jax.tree_util.tree_structure(params)
+    assert len(g_leaves) == len(p_leaves) and len(g_leaves) > 0
+    for g, p in zip(g_leaves, p_leaves, strict=True):
+        assert g.shape == p.shape
+        assert bool(jnp.all(jnp.isfinite(g)))
+
+
+def test_antithetic_es_matches_analytic_gradient():
+    """On a smooth quadratic the ES estimate aligns with the true gradient."""
+    key = jax.random.PRNGKey(3)
+    w0 = jnp.array([1.0, -2.0, 0.5, 3.0, -1.5], dtype=jnp.float32)
+    model = VecModel(w0)
+    center = jnp.array([0.2, 0.1, -0.3, 0.0, 0.7], dtype=jnp.float32)
+
+    def loss_true(m):
+        return 0.5 * jnp.sum((m.w[...] - center) ** 2)
+
+    analytic = w0 - center  # ∇ = w - center
+
+    grads = es_gradient(model, loss_true, key, num_samples=400, sigma=0.01)
+    g_es = jax.flatten_util.ravel_pytree(grads)[0]
+
+    cos = float(
+        jnp.dot(g_es, analytic)
+        / (jnp.linalg.norm(g_es) * jnp.linalg.norm(analytic) + 1e-12)
+    )
+    assert cos > 0.5, f"ES estimate poorly aligned with analytic grad: cos={cos}"
+
+
+def test_diagnostics_keys():
+    """Diagnostics helper exposes the correction magnitudes."""
+    model = VecModel(jnp.arange(5.0))
+
+    def loss_s(m):
+        return jnp.sum(m.w[...] ** 2)
+
+    def loss_t(m):
+        return jnp.sum((m.w[...] - 1.0) ** 2)
+
+    diag = hybrid_diagnostics(
+        model, loss_s, loss_t, jax.random.PRNGKey(4), num_samples=32, sigma=0.02
+    )
+    for k in ("cosine", "g_orth_norm", "g_s_norm", "g_es_norm", "proj"):
+        assert k in diag
+        assert bool(jnp.isfinite(diag[k]))
+    # cosine is a valid cosine similarity.
+    assert -1.0 - 1e-4 <= float(diag["cosine"]) <= 1.0 + 1e-4
+
+
+def test_end_to_end_hybrid_step_keeps_true_loss_finite(rngs):
+    """A few hybrid steps on a tiny spiking classifier keep the true loss sane."""
+    model = TinyClassifier(6, 12, 3, axn.superspike(), rngs=rngs)
+    T, B, C = 8, 4, 6
+    dk = jax.random.PRNGKey(5)
+    x = (jax.random.uniform(dk, (T, B, C)) < 0.3).astype(jnp.float32)
+    y = jnp.array([0, 1, 2, 1])
+
+    # loss_true uses the same hard-Heaviside forward the model already computes;
+    # the surrogate only differs in the backward pass, so they share this fn but
+    # are used differently (grad vs. forward-only ES).
+    ce = fn.integral_crossentropy(smoothing=0.2)
+
+    def loss_fn(m, xb, yb):
+        return ce(m(xb), yb)
+
+    optimizer = nnx.Optimizer(model, optax.adam(5e-3), wrt=nnx.Param)
+    step = make_hybrid_train_step(loss_fn, loss_fn, num_samples=8, sigma=0.01, lam=0.5)
+
+    key = jax.random.PRNGKey(6)
+    losses = []
+    for _ in range(4):
+        key, sub = jax.random.split(key)
+        losses.append(float(step(model, optimizer, sub, x, y)))
+
+    for value in losses:
+        assert jnp.isfinite(value)
+    # Should not blow up: final within a small tolerance of (or below) the start.
+    assert losses[-1] <= losses[0] + 0.5

--- a/tests/test_zoo.py
+++ b/tests/test_zoo.py
@@ -1,0 +1,78 @@
+"""Tests for the spyx.experimental.zoo recipe registry.
+
+All recipes run on synthetic data (no downloads) and are sized for a few
+seconds total on CPU. Not marked ``network``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from spyx.experimental.zoo import REGISTRY, Recipe, get, list_recipes
+
+# Gradient-trained recipes whose demo loss should decrease.
+_GRADIENT_RECIPES = {"classification-rsnn", "language-s5"}
+
+
+def _finite(values) -> bool:
+    return bool(jnp.all(jnp.isfinite(jnp.asarray(values))))
+
+
+def test_registry_spans_three_applications():
+    assert len(REGISTRY) >= 3
+    applications = {r.application for r in REGISTRY.values()}
+    assert applications == {"control", "classification", "language"}
+
+
+def test_registry_fields_populated():
+    for name, recipe in REGISTRY.items():
+        assert isinstance(recipe, Recipe)
+        assert recipe.name == name
+        for field in ("name", "application", "method", "architecture", "describe"):
+            value = getattr(recipe, field)
+            assert isinstance(value, str) and value, f"{name}.{field} empty"
+        assert callable(recipe.build)
+        assert callable(recipe.synthetic_batch)
+        assert callable(recipe.loss)
+        assert callable(recipe.demo)
+
+
+def test_helpers():
+    assert get("control-lif-es").application == "control"
+    with pytest.raises(KeyError):
+        get("does-not-exist")
+    assert len(list_recipes()) == len(REGISTRY)
+    assert {r.name for r in list_recipes(application="language")} == {"language-s5"}
+    assert {r.name for r in list_recipes(method="surrogate")} == {"classification-rsnn"}
+    assert {r.name for r in list_recipes(method="gradient")} == {"language-s5"}
+    assert list_recipes(application="control", method="surrogate") == []
+
+
+@pytest.mark.parametrize("name", sorted(REGISTRY))
+def test_build_and_loss_finite(name):
+    recipe = get(name)
+    model = recipe.build(nnx.Rngs(0))
+    assert isinstance(model, nnx.Module)
+    batch = recipe.synthetic_batch(jax.random.PRNGKey(1))
+    assert isinstance(batch, tuple)
+    value = recipe.loss(model, *batch)
+    assert _finite(value)
+
+
+@pytest.mark.parametrize("name", sorted(REGISTRY))
+def test_demo_runs_and_history_finite(name):
+    recipe = get(name)
+    history = recipe.demo(steps=6)
+    assert len(history) == 6
+    assert _finite(history)
+
+
+@pytest.mark.parametrize("name", sorted(_GRADIENT_RECIPES))
+def test_gradient_recipes_improve(name):
+    recipe = get(name)
+    history = recipe.demo(steps=25)
+    # Loss at the end should be no worse than at the start (small tolerance).
+    assert history[-1] <= history[0] + 1e-4


### PR DESCRIPTION
## What & why

Spyx had modules but no answer to the first question a new researcher asks: **"how do I train this thing?"** This PR adds a method-first organization — training methods indexed by the *order of information* they exploit — and maps it onto applications and architectures, plus two new experimental building blocks it references.

## Docs (user-facing)

- **`explanation/training-methods.md`** — the spine. Five families: 0th-order/evolutionary, 1st-order/surrogate gradient, transfer (conversion + QAT), local/bio-inspired (honestly flagged as roadmap — issues #27/#28), and the 0+1 hybrid. Each with when-to-use, the trade-off, and the concrete Spyx entry point.
- **`explanation/choosing-an-approach.md`** — two decision matrices (method × application, method × architecture) and a `task → application → architecture → method` "start here" flow.
- Wired first into the **Explanation** nav; linked from the home page.

## `spyx.experimental.zoo` — reference recipes

Runnable recipes keyed by application, tagged by **method × architecture**, all on synthetic data (no downloads, sub-second smoke paths):

| recipe | application | method | architecture |
|---|---|---|---|
| `control-lif-es` | control / RL | evolutionary (evosax `Open_ES`) | LIF-MLP |
| `classification-rsnn` | classification | surrogate (`axn.arctan`) | RSNN |
| `language-s5` | language | gradient | S5 (`ssm.S5Diag`) |

`REGISTRY` / `list_recipes` / `get`; each recipe exposes `build` / `synthetic_batch` / `demo`.

## `spyx.experimental.hybrid` — the 0+1 trainer

The novel method: a surrogate gradient corrected by an **antithetic-NES estimate of the true (hard-spike) loss gradient, projected orthogonal to the surrogate** — the surrogate supplies the cheap bulk descent direction, ES supplies only the correction in the subspace the surrogate is blind to. It is the **complement of Guided-ES** (which restricts ES search to the gradient's subspace; here we restrict it to the orthogonal complement).

`hybrid_gradient`, `make_hybrid_train_step`, `es_gradient`, `hybrid_diagnostics`.

**Honest result** (`research/new/hybrid_evo_surrogate/`, three-arm study): in the cheap smoke regime the pure surrogate wins — `‖g_orth‖ ≈ 41 ≫ ‖g_s‖ ≈ 8.6` at λ=0.5, so the high-variance correction dominates. The writeup reports this as a boundary result and proposes a small self-normalising λ (`λ·‖g_s‖/‖g_orth‖`) with larger K as the fix, not a win it didn't earn.

## Verification

- `uv run pytest -m "not network"` — **202 passed, 1 skipped** (16 new tests across zoo + hybrid)
- `uv run ruff check` / `uv run ty check` — clean
- `uv run mkdocs build --strict` — clean
- Each stream was built and **adversarially verified** by an independent agent (strict build re-run, real pytest, and a hand-check of the NES estimator scaling + orthogonality of the projection — `⟨g_orth, g_s⟩ ≈ -3e-7`).

Everything new lands under `spyx.experimental` (unstable-API contract); the stable core is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)