### PR TITLE
docs: reflect newly-merged features (compile_fit/Solver, SGES, matfree)

### DIFF
--- a/docs/explanation/training-methods.md
+++ b/docs/explanation/training-methods.md
@@ -165,6 +165,15 @@ hyperparameters (which layers, which qtype).
     `spyx.quant.spiking_feedforward_rules` builds exactly this, and it is a genuine
     free efficiency gain rather than an accuracy trade.
 
+**Build multiplication-light, don't just convert.** Post-training quantization
+(above) *converts* a trained dense model; the complementary path is to **train the
+low-precision architecture from scratch**. [`spyx.experimental.matfree`](../reference/experimental.md)
+supplies the native primitives — ternary (BitNet) `TernaryLinear` whose forward
+pass is signed accumulations, and shift-add (DeepShift) `ShiftAddLinear` whose
+weights are powers of two, plus `MatMulFreeBlock` / `MLGRU` — all trained through
+straight-through estimators. Use `spyx.quant` to make an existing model cheaper;
+use `matfree` to design a matmul-free one.
+
 ## Local / bio-inspired — mostly roadmap
 
 **Idea.** Global BPTT is biologically implausible and memory-hungry (it stores the
@@ -233,11 +242,23 @@ antithetic ES batch of hard-spike forward passes — more compute per update tha
 pure 1st-order, far less than pure 0th-order — in exchange for a descent direction
 that is unbiased in the subspace the surrogate misses.
 
-**Spyx entry point.** The concrete implementation is being staged at
-**`spyx.experimental.hybrid`** (import as `from spyx.experimental.hybrid import
-...`). Until it lands you can assemble the pieces by hand:
-[`spyx.axn`](../reference/axn.md) for \(g_s\), `evosax`'s antithetic sampling for
-\(g_h\), and a projection you drop into your `nnx.value_and_grad` step.
+**Spyx entry point.** [`spyx.experimental.hybrid`](../reference/experimental.md)
+(`from spyx.experimental.hybrid import hybrid_gradient, make_hybrid_train_step, ...`)
+is the drop-in implementation: `hybrid_gradient` returns the corrected gradient
+pytree, `make_hybrid_train_step` wraps it into an `nnx` step, and
+`hybrid_diagnostics` exposes `cosine(g_h, g_s)` / `‖g_orth‖` so you can see the
+correction magnitude. A `normalize=True` mode makes the correction weight a
+*fraction of the surrogate step* (`λ·‖g_s‖/‖g_orth‖`), which stops a high-variance
+ES term from swamping the bulk direction.
+
+**Surrogate-steered variant (SGES).** `sges_gradient` / `make_sges_hybrid_train_step`
+use the surrogate direction as a **guiding subspace**: the along-guide derivative
+is measured exactly and ES samples are spent only on the orthogonal complement,
+cutting estimate variance several-fold vs isotropic ES (verified ~7× on the study
+task). Honest status: the ES variants remove the raw failure mode and SGES reduces
+variance, but on easy, well-matched tasks the surrogate still wins — the hybrid's
+edge needs a genuinely large-surrogate-bias regime. See the study and numbers under
+[`research/new/hybrid_evo_surrogate/`](https://github.com/kmheckel/spyx/tree/main/research/new/hybrid_evo_surrogate).
 
 ## Summary
 
@@ -245,8 +266,8 @@ that is unbiased in the subspace the surrogate misses.
 |---|---|---|---|---|
 | **Evolutionary** | loss values | control/RL, non-differentiable or hard-spike objectives | many forward evals | `evosax` + `spyx.experimental.zoo` |
 | **Surrogate gradient** | surrogate loss gradient | classification, sequence modelling — the default | 1 fwd+bwd / step | [`spyx.axn`](../reference/axn.md) + [`spyx.optimize.fit`](../reference/optimize.md) |
-| **Conversion & QAT** | a pretrained model | deploying an existing model spiking / low-precision | fine-tune, longer `T` | [`spyx.quant`](../reference/quant.md) |
+| **Conversion & QAT** | a pretrained model | deploying an existing model spiking / low-precision | fine-tune, longer `T` | [`spyx.quant`](../reference/quant.md) (convert) · [`spyx.experimental.matfree`](../reference/experimental.md) (build matmul-free from scratch) |
 | **Local / bio-inspired** | local signals | online / on-chip learning | — (roadmap) | issues [#27](https://github.com/kmheckel/spyx/issues/27), [#28](https://github.com/kmheckel/spyx/issues/28) |
-| **0+1 hybrid** | surrogate grad + hard-spike ES | fixing surrogate bias on the hard objective | fwd+bwd **+** small ES batch | `spyx.experimental.hybrid` |
+| **0+1 hybrid** | surrogate grad + hard-spike ES | fixing surrogate bias on the hard objective | fwd+bwd **+** small ES batch | [`spyx.experimental.hybrid`](../reference/experimental.md) (incl. SGES) |
 
 Now pick one for *your* task and architecture: [Choosing an approach](choosing-an-approach.md).

--- a/docs/how-to/train.md
+++ b/docs/how-to/train.md
@@ -89,6 +89,24 @@ Notes:
 - `@nnx.jit` compiles the whole step, including the time scan inside `snn.run`; the model and optimizer are updated in place.
 - To compose Optax transforms, just chain them: `optax.chain(optax.centralize(), optax.lion(3e-4))`.
 
+## Option 3: `spyx.optimize.compile_fit` — whole-loop JIT
+
+When you want maximum throughput and the dataset fits on the accelerator, `compile_fit` stages the data on-device and `jax.lax.scan`s the entire epochs × batches loop under a **single** `jax.jit` — no per-step Python, no re-tracing. A whole run becomes one compiled kernel.
+
+```python
+model, history = opt.compile_fit(
+    model,
+    optax.lion(3e-4),          # an Optax tx is auto-wrapped in the backprop Solver
+    loss_fn,
+    train_data=(events, targets),   # arrays/pytrees, staged on-device
+    epochs=30,
+    eval_data=(test_events, test_targets),
+    metric_fn=spyx.fn.integral_accuracy(),
+)
+```
+
+`compile_fit` is optimiser-agnostic via the `Solver` protocol: pass an Optax transform for the surrogate-gradient path, or a custom `Solver` (`init` / `step`) to run an evolutionary strategy through the same machinery — see [`spyx.experimental.hybrid`](../reference/experimental.md) for the ES / SGES solvers. Use `fit` (Option 1) instead when the data is streamed or too large to stage.
+
 ## Add activity regularisation
 
 To discourage silent or over-active neurons, tap the intermediate spike trains in a custom module and add `spyx.fn.silence_reg` / `spyx.fn.sparsity_reg` penalties:

--- a/docs/reference/experimental.md
+++ b/docs/reference/experimental.md
@@ -27,7 +27,8 @@ of the library.
 | [`spyx.experimental.raven`](#spyxexperimentalraven) | Module | Routing-slot memory (`RavenRSM`), spiking sibling (`SpikingSlotMemory`), `SlotRouter`, and the `make_recall_batch` MQAR generator. |
 | [`spyx.experimental.compress`](#spyxexperimentalcompress) | Module | Bit-packed activation storage for memory-efficient BPTT. |
 | [`spyx.experimental.stochastic`](#spyxexperimentalstochastic) | Module | Stochastic (Bernoulli-spiking) and parallelizable prototypes: `SPSN`, `StochasticAssociative{LIF,CuBaLIF}`, and the `sigmoid_bernoulli` activations. |
-| [`spyx.experimental.hybrid`](#spyxexperimentalhybrid) | Module | The 0+1 hybrid trainer: surrogate gradient + antithetic-NES correction projected orthogonal to the surrogate (`hybrid_gradient`, `make_hybrid_train_step`, `es_gradient`, `hybrid_diagnostics`). |
+| [`spyx.experimental.hybrid`](#spyxexperimentalhybrid) | Module | The 0+1 hybrid trainer: surrogate gradient + antithetic-NES correction projected orthogonal to the surrogate (`hybrid_gradient`, `make_hybrid_train_step`, `es_gradient`, `hybrid_diagnostics`), plus the surrogate-steered **Self-Guided ES** variant (`sges_gradient`, `make_sges_hybrid_train_step`) — the surrogate direction is SGES's guiding subspace, so ES is spent on the orthogonal complement at several-fold lower variance. |
+| [`spyx.experimental.matfree`](#spyxexperimentalmatfree) | Module | Matmul-free linear primitives — ternary (BitNet: `TernaryLinear`, `TernaryMLP`) and shift-add (DeepShift: `ShiftAddLinear`) layers that replace dense multiplies with accumulations / bit-shifts, plus `MatMulFreeBlock`, `MLGRU`, `RMSNorm`, and the `ternary_weights` / `power_of_two_weights` / `activation_quant` STE helpers. The native train-from-scratch counterpart to the post-training [`spyx.quant.bitnet_ternary_rules`](quant.md) path. |
 | [`spyx.experimental.zoo`](#spyxexperimentalzoo) | Package | Runnable reference recipes keyed by application (control / classification / language) and tagged by training method × architecture (`REGISTRY`, `list_recipes`, `get`). |
 | [`spyx.experimental.onnx`](#spyxexperimentalonnx) | Module | Export a spiking model to ONNX — per-timestep step, or the whole `spyx.nn.run` loop as a native ONNX `Scan`/`Loop`. Conversion deps imported lazily. |
 
@@ -74,6 +75,16 @@ Runnable recipes tagged by application × training method × architecture. Each
 with `list_recipes(application=..., method=...)`.
 
 ::: spyx.experimental.zoo
+
+## spyx.experimental.matfree
+
+Multiplication-light layers you **build with**, rather than convert to: ternary
+(BitNet) weights collapse the matmul to signed accumulations, power-of-two
+(DeepShift) weights to bit-shifts. Trained from scratch / QAT via straight-through
+estimators. See [Training methods](../explanation/training-methods.md) for where
+this sits relative to post-training quantization ([`spyx.quant`](quant.md)).
+
+::: spyx.experimental.matfree
 
 ## spyx.experimental.onnx
 

--- a/docs/reference/optimize.md
+++ b/docs/reference/optimize.md
@@ -1,5 +1,9 @@
 # spyx.optimize
 
-High-level training loop that wraps `nnx.Optimizer` + `nnx.value_and_grad`. Use `fit(...)` for the common case or `make_train_step` / `make_eval_step` to roll your own loop.
+High-level training loops for Spyx models. Three entry points, in increasing order of "how much is compiled":
+
+- **`fit(...)`** — a Python epoch loop driving a per-step `@nnx.jit`. The common case; returns a `History` of per-epoch metrics. Use `make_train_step` / `make_eval_step` to roll your own loop with the same JIT'd pieces.
+- **`compile_fit(...)`** — stages the whole dataset on-device and `jax.lax.scan`s the loop over epochs × batches under a *single* `jax.jit`, so a full run compiles to one XLA kernel with no per-step Python or re-tracing (the throughput pattern the Spyx paper relies on).
+- **`Solver` protocol** — `compile_fit` is optimiser-agnostic: pass an Optax `GradientTransformation` (auto-wrapped by `backprop(...)` for the surrogate-gradient path) *or* a custom `Solver` implementing `init` / `step`, which is how the evolutionary trainers (ES / CMA-ES, see [`spyx.experimental.hybrid`](experimental.md)) drop into the same whole-loop-JIT machinery.
 
 ::: spyx.optimize


### PR DESCRIPTION
Brings the docs current with the code before the 1.0 release. `compile_fit`/`Solver` (#52), SGES (#53), and `matfree` (#54) landed in the library but had **zero** doc coverage, and the hybrid explanation still said it was "being staged."

## Changes
- **`reference/optimize.md`** — document `compile_fit` (whole-loop JIT) and the `Solver` protocol next to `fit()`.
- **`how-to/train.md`** — new "Option 3: `compile_fit` — whole-loop JIT" with a runnable example.
- **`reference/experimental.md`** — add SGES (`sges_gradient` / `make_sges_hybrid_train_step`) to the hybrid row; add a `matfree` table row + a rendered `::: spyx.experimental.matfree` section (it wasn't rendered anywhere before).
- **`explanation/training-methods.md`** — correct the stale "until it lands" hybrid text; document the SGES variant with its **honest** status (variance-reduced, but needs a large-bias regime to beat surrogate); add `matfree` as the build-from-scratch counterpart to `spyx.quant`; refresh the summary table.

`mkdocs build --strict` passes. Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)