### PR TITLE
research: profile matmul vs neuron-scan before Pallas (#24)

### DIFF
--- a/research/new/pallas_neurons/README.md
+++ b/research/new/pallas_neurons/README.md
@@ -1,0 +1,95 @@
+# Pallas neurons — profiling first (issue #24)
+
+## Question
+
+[Issue #24](https://github.com/kmheckel/spyx/issues/24) asks whether a **Pallas
+kernel** should implement the neuron dynamics for speed. A fused kernel is only
+worth writing if the **neuron update is the bottleneck** — but the neuron step is
+elementwise **O(H)** while the `Linear` feeding it is **O(H²)**, so which one
+dominates wall-clock is regime-dependent (hidden width `H`, timesteps `T`,
+device). This study measures that *before* anyone writes a kernel.
+
+## Method
+
+`profile_neurons.py` runs a component ablation through [`spyx.bench`](../../../src/spyx/bench.py)
+(median latency, XLA-cost-model FLOPs, peak mem) at matched `(H, T, B)`:
+
+| Component | What it isolates | Driver |
+| --- | --- | --- |
+| `linear` | `Sequential(Linear(H,H))` — matmul per timestep | `spyx.nn.run` (scan) |
+| `lif_scan` | `LIF((H,))` — the sequential recurrence | `spyx.nn.run` (scan) |
+| `psu_parallel` | `PSU_LIF((H,))` — the associative-scan neuron | its `.parallel` |
+| `linear_lif` | `Sequential(Linear(H,H), LIF((H,)))` — a real layer | `spyx.nn.run` |
+
+Read-outs per regime:
+- **`lif_scan / linear`** — > 1 means the neuron scan dominates → a fused
+  Pallas / parallel kernel can help; < 1 means the matmul dominates → a faster
+  neuron barely moves wall-clock (optimise the `Linear` instead).
+- **`lif_scan / psu_parallel`** — what the *portable* associative-scan already
+  buys for linearizable neurons, i.e. the win you can get **without** Pallas.
+
+## How to run
+
+```bash
+uv run python research/new/pallas_neurons/profile_neurons.py            # default sweep
+HIDDENS=128,512 SEQLENS=256,1024 BATCH=128 uv run python research/new/pallas_neurons/profile_neurons.py
+```
+
+Writes `profile_results.json` (records `backend`/`device`). **Run it on the target
+device** — the crossover shifts with hardware: a GPU's higher matmul throughput
+pushes the neuron-bound regime to *larger* `H` than CPU does.
+
+## Findings
+
+Sweep on **CPU** (`backend=cpu`, B=64, 20 iters, 83 s; `profile_results.json`).
+`neuron/matmul` = `lif_scan` latency ÷ `linear` latency — **< 1 means the matmul
+dominates.**
+
+| H | T | neuron/matmul (fwd) | neuron/matmul (fwd+bwd) | assoc-scan ×vs-scan |
+|---|---|---|---|---|
+| 64 | 64 | 0.35 | 0.67 | 0.62 |
+| 64 | 256 | 0.29 | **1.06** | 2.12 |
+| 64 | 1024 | 0.38 | 0.97 | 1.25 |
+| 256 | 64 | 0.20 | 0.27 | 1.23 |
+| 256 | 256 | 0.21 | 0.46 | 1.13 |
+| 256 | 1024 | 0.24 | 0.53 | 0.48 |
+| 1024 | 64 | 0.20 | 0.44 | 0.89 |
+| 1024 | 256 | 0.32 | 0.32 | 0.52 |
+| 1024 | 1024 | 0.22 | 0.35 | 0.40 |
+
+**1. Matmul-bound in every forward regime on CPU.** The neuron scan is only
+**20–38 %** of the `Linear` it follows, and **16–33 %** of a full `Linear+LIF`
+layer. A fused Pallas neuron kernel cannot move forward wall-clock here — the
+`Linear` (O(H²)) is the time, the neuron (O(H)) is glue.
+
+**2. The one place the neuron approaches parity is *small-width training.*** In the
+backward pass (BPTT — what actually costs during training) the ratio climbs, and
+at **H=64 it reaches ~0.7–1.06×** the matmul: the surrogate-gradient scan backward
+is comparatively expensive when the matmul is small. So the neuron kernel's payoff,
+if any, lives in **narrow networks during training** — which, notably, is also the
+regime where evolution is competitive (the thesis result). At H≥256 it stays
+matmul-bound (0.27–0.53×) even in the backward.
+
+**3. Associative-scan is *not* a free win — and not even always a win.** The
+portable `PSU_LIF` parallel path beats the sequential scan only at **small H /
+moderate T** (up to 2.1×) and **loses up to 2.5×** at large H·T (0.40× at
+H=1024,T=1024), with **no memory saving** (both store the full trajectory:
+identical peak MB). On CPU there is no parallel slack to amortise its extra work.
+This matches the `PSU_LIF` note that its wins come "by device slack" — the parallel
+route is itself device-gated, so it must be validated on the target GPU too.
+
+**4. Everything above is CPU; the decision needs GPU numbers.** A GPU's far higher
+matmul throughput *raises the neuron's relative share*, so the crossover into
+neuron-bound territory can appear at H/T sizes people actually train — exactly
+where CPU says "matmul-bound." Re-run `profile_neurons.py` on the 8060S / gfx1151
+ROCm venv before deciding; that JSON, not this one, is the evidence for #24.
+
+## Decision rule
+
+- **Neuron-bound** on the target device at the sizes you train → worth a fused
+  kernel. First try extending the **portable** `associative_scan` path
+  (`PSU_LIF`) for linearizable neurons; reserve Pallas for the hard-reset / ALIF
+  neurons that *can't* be linearized (see the discussion in issue #24).
+- **Matmul-bound** everywhere you care about → skip the neuron kernel; the Linear
+  (or its precision — see [`spyx.experimental.matfree`](../../../src/spyx/experimental/matfree.py))
+  is where the time is.

--- a/research/new/pallas_neurons/profile_neurons.py
+++ b/research/new/pallas_neurons/profile_neurons.py
@@ -1,0 +1,186 @@
+"""Where does SNN wall-clock actually go — the matmul, or the neuron scan?
+
+Motivation for the Pallas-neurons question (issue #24): a fused Pallas kernel for
+neuron dynamics only pays off if the **neuron update** is the bottleneck. But the
+neuron step is elementwise O(H) while the preceding `Linear` is O(H^2), so which
+dominates is *regime-dependent* — small/wide, short/long. This harness measures the
+crossover before anyone writes a kernel.
+
+Component ablation at matched (hidden width H, timesteps T, batch B), via
+`spyx.bench` (median latency, XLA-cost FLOPs, peak mem):
+
+- **linear**      `Sequential(Linear(H,H))` — matmul per timestep, no neuron.
+- **lif_scan**    `LIF((H,))` — the sequential `jax.lax.scan` neuron (bench drives
+                   it with `spyx.nn.run`; LIF has no `.parallel`).
+- **psu_parallel** `PSU_LIF((H,))` — the *associative-scan* neuron (bench auto-uses
+                   its `.parallel` method). The portable parallel alternative to a
+                   Pallas kernel, already in the library.
+- **linear_lif**  `Sequential(Linear(H,H), LIF((H,)))` — the realistic layer.
+
+Read-out per regime:
+- `lif / linear` > 1  → the neuron scan dominates → a fused Pallas/parallel kernel
+  is worth it here. < 1 → the matmul dominates → a faster neuron barely moves
+  wall-clock (optimise the Linear instead).
+- `lif_scan / psu_parallel` → what the *portable* associative-scan already buys,
+  for the (linearizable) neurons that can use it.
+
+Device caveat: the crossover shifts with hardware — a GPU's higher matmul
+throughput pushes the neuron-dominated regime to larger H than CPU. Run this on the
+target device; the JSON records `backend`. Writes `profile_results.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import jax
+from flax import nnx
+
+import spyx.bench as bench
+import spyx.nn as snn
+
+HIDDENS = [int(h) for h in os.environ.get("HIDDENS", "64,256,1024").split(",")]
+SEQLENS = [int(t) for t in os.environ.get("SEQLENS", "64,256,1024").split(",")]
+BATCH = int(os.environ.get("BATCH", "64"))
+N_ITERS = int(os.environ.get("N_ITERS", "20"))
+N_WARMUP = int(os.environ.get("N_WARMUP", "3"))
+
+
+def components(h):
+    """Fresh-module thunks so each benchmark builds its own params."""
+    return {
+        "linear": lambda: snn.Sequential(
+            nnx.Linear(h, h, use_bias=False, rngs=nnx.Rngs(0))
+        ),
+        "lif_scan": lambda: snn.LIF((h,), rngs=nnx.Rngs(0)),
+        "psu_parallel": lambda: snn.PSU_LIF((h,), rngs=nnx.Rngs(0)),
+        "linear_lif": lambda: snn.Sequential(
+            nnx.Linear(h, h, use_bias=False, rngs=nnx.Rngs(0)),
+            snn.LIF((h,), rngs=nnx.Rngs(0)),
+        ),
+    }
+
+
+def _verdict(ratio):
+    if ratio >= 1.5:
+        return "NEURON-BOUND — fused kernel worth it"
+    if ratio >= 0.67:
+        return "balanced — profile the specific model"
+    return "MATMUL-BOUND — neuron kernel won't move wall-clock"
+
+
+def main():
+    backend = jax.default_backend()
+    dev = str(jax.devices()[0])
+    print(
+        f"backend={backend} device={dev}  B={BATCH} iters={N_ITERS}  "
+        f"H={HIDDENS} T={SEQLENS}",
+        flush=True,
+    )
+    print(
+        "  (crossover is device-dependent; a GPU pushes NEURON-BOUND to larger H)\n",
+        flush=True,
+    )
+
+    t0 = time.perf_counter()
+    rows = []
+    for h in HIDDENS:
+        results = bench.compare(
+            components(h),
+            (h,),
+            seq_lens=SEQLENS,
+            batch=BATCH,
+            n_warmup=N_WARMUP,
+            n_iters=N_ITERS,
+            backward=True,
+        )
+        # index by (name, T)
+        idx = {(r.name, r.seq_len): r for r in results}
+        for t in SEQLENS:
+            lin = idx[("linear", t)]
+            lif = idx[("lif_scan", t)]
+            psu = idx[("psu_parallel", t)]
+            comb = idx[("linear_lif", t)]
+            neuron_vs_matmul = lif.fwd_latency_ms / max(lin.fwd_latency_ms, 1e-9)
+            neuron_share = lif.fwd_latency_ms / max(comb.fwd_latency_ms, 1e-9)
+            parallel_speedup = lif.fwd_latency_ms / max(psu.fwd_latency_ms, 1e-9)
+            fb = {
+                k: idx[(k, t)].fwd_bwd_latency_ms
+                for k in ("linear", "lif_scan", "psu_parallel", "linear_lif")
+            }
+            neuron_vs_matmul_bwd = (
+                (fb["lif_scan"] / fb["linear"]) if fb["linear"] else None
+            )
+            row = {
+                "H": h,
+                "T": t,
+                "batch": BATCH,
+                "fwd_ms": {
+                    "linear": lin.fwd_latency_ms,
+                    "lif_scan": lif.fwd_latency_ms,
+                    "psu_parallel": psu.fwd_latency_ms,
+                    "linear_lif": comb.fwd_latency_ms,
+                },
+                "fwd_bwd_ms": fb,
+                "peak_mem_mb": {
+                    "lif_scan": lif.peak_mem_mb,
+                    "psu_parallel": psu.peak_mem_mb,
+                    "linear_lif": comb.peak_mem_mb,
+                },
+                "neuron_vs_matmul_fwd": neuron_vs_matmul,
+                "neuron_vs_matmul_fwd_bwd": neuron_vs_matmul_bwd,
+                "neuron_share_of_combined_fwd": neuron_share,
+                "parallel_speedup_scan_over_assoc": parallel_speedup,
+                "verdict_fwd": _verdict(neuron_vs_matmul),
+            }
+            rows.append(row)
+            print(
+                f"H={h:<5} T={t:<5} | linear {lin.fwd_latency_ms:7.2f}ms  "
+                f"lif_scan {lif.fwd_latency_ms:7.2f}ms  psu {psu.fwd_latency_ms:7.2f}ms "
+                f"| neuron/matmul {neuron_vs_matmul:5.2f}x  "
+                f"assoc-speedup {parallel_speedup:5.2f}x  | {_verdict(neuron_vs_matmul)}",
+                flush=True,
+            )
+    dt = time.perf_counter() - t0
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "profile_results.json"), "w") as f:
+        json.dump(
+            {
+                "config": {
+                    "backend": backend,
+                    "device": dev,
+                    "hiddens": HIDDENS,
+                    "seqlens": SEQLENS,
+                    "batch": BATCH,
+                    "n_iters": N_ITERS,
+                    "wall_s": dt,
+                },
+                "rows": rows,
+            },
+            f,
+            indent=2,
+        )
+    print(f"\nwrote profile_results.json  ({dt:.0f}s)", flush=True)
+
+    # one-line takeaway: the largest-H, longest-T regime and the smallest one
+    neuron_bound = [r for r in rows if r["neuron_vs_matmul_fwd"] >= 1.0]
+    if neuron_bound:
+        print(
+            f"NEURON-BOUND in {len(neuron_bound)}/{len(rows)} regimes "
+            f"(e.g. H={neuron_bound[0]['H']} T={neuron_bound[0]['T']}): "
+            "a fused Pallas / associative-scan kernel can help there.",
+            flush=True,
+        )
+    else:
+        print(
+            "MATMUL-BOUND in every tested regime on this device: optimise the "
+            "Linear (or shrink it) before writing a neuron kernel.",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/research/new/pallas_neurons/profile_results.json
+++ b/research/new/pallas_neurons/profile_results.json
@@ -1,0 +1,264 @@
+{
+  "config": {
+    "backend": "cpu",
+    "device": "cpu:0",
+    "hiddens": [
+      64,
+      256,
+      1024
+    ],
+    "seqlens": [
+      64,
+      256,
+      1024
+    ],
+    "batch": 64,
+    "n_iters": 20,
+    "wall_s": 82.88047962498968
+  },
+  "rows": [
+    {
+      "H": 64,
+      "T": 64,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 0.3769705072045326,
+        "lif_scan": 0.13139250222593546,
+        "psu_parallel": 0.21143349295016378,
+        "linear_lif": 0.5325884849298745
+      },
+      "fwd_bwd_ms": {
+        "linear": 0.8614179969299585,
+        "lif_scan": 0.5760910134995356,
+        "psu_parallel": 0.8839499932946637,
+        "linear_lif": 0.8013799961190671
+      },
+      "peak_mem_mb": {
+        "lif_scan": 2.000499725341797,
+        "psu_parallel": 2.000499725341797,
+        "linear_lif": 2.031749725341797
+      },
+      "neuron_vs_matmul_fwd": 0.3485484930911211,
+      "neuron_vs_matmul_fwd_bwd": 0.6687705800815505,
+      "neuron_share_of_combined_fwd": 0.2467054882781324,
+      "parallel_speedup_scan_over_assoc": 0.6214365585726075,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 64,
+      "T": 256,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 1.5459025016753003,
+        "lif_scan": 0.45383500400930643,
+        "psu_parallel": 0.21371801267378032,
+        "linear_lif": 1.6166360001079738
+      },
+      "fwd_bwd_ms": {
+        "linear": 2.1896154939895496,
+        "lif_scan": 2.3130585032049567,
+        "psu_parallel": 3.5840174969052896,
+        "linear_lif": 3.7244170089252293
+      },
+      "peak_mem_mb": {
+        "lif_scan": 8.000499725341797,
+        "psu_parallel": 8.000499725341797,
+        "linear_lif": 8.031749725341797
+      },
+      "neuron_vs_matmul_fwd": 0.293572850498323,
+      "neuron_vs_matmul_fwd_bwd": 1.0563765691073412,
+      "neuron_share_of_combined_fwd": 0.28072800802344816,
+      "parallel_speedup_scan_over_assoc": 2.1235224786693165,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 64,
+      "T": 1024,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 5.838680997840129,
+        "lif_scan": 2.2369850194081664,
+        "psu_parallel": 1.7919314850587398,
+        "linear_lif": 6.680532489554025
+      },
+      "fwd_bwd_ms": {
+        "linear": 12.72563249222003,
+        "lif_scan": 12.348992982879281,
+        "psu_parallel": 16.772832517744973,
+        "linear_lif": 22.79317649663426
+      },
+      "peak_mem_mb": {
+        "lif_scan": 32.0004997253418,
+        "psu_parallel": 32.0004997253418,
+        "linear_lif": 32.0317497253418
+      },
+      "neuron_vs_matmul_fwd": 0.38313191288163917,
+      "neuron_vs_matmul_fwd_bwd": 0.9704030813736755,
+      "neuron_share_of_combined_fwd": 0.33485130457879136,
+      "parallel_speedup_scan_over_assoc": 1.248365262879924,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 256,
+      "T": 64,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 2.1600745239993557,
+        "lif_scan": 0.4400039906613529,
+        "psu_parallel": 0.3578394971555099,
+        "linear_lif": 2.805465497658588
+      },
+      "fwd_bwd_ms": {
+        "linear": 7.303952006623149,
+        "lif_scan": 1.9499644986353815,
+        "psu_parallel": 3.4708499879343435,
+        "linear_lif": 8.9348394976696
+      },
+      "peak_mem_mb": {
+        "lif_scan": 8.001964569091797,
+        "psu_parallel": 8.001964569091797,
+        "linear_lif": 8.501964569091797
+      },
+      "neuron_vs_matmul_fwd": 0.20369852325589674,
+      "neuron_vs_matmul_fwd_bwd": 0.26697389260871013,
+      "neuron_share_of_combined_fwd": 0.15683814006216637,
+      "parallel_speedup_scan_over_assoc": 1.2296127011103415,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 256,
+      "T": 256,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 10.66775449726265,
+        "lif_scan": 2.26008849858772,
+        "psu_parallel": 1.9974035094492137,
+        "linear_lif": 10.75033048982732
+      },
+      "fwd_bwd_ms": {
+        "linear": 25.467490006121807,
+        "lif_scan": 11.764826995204203,
+        "psu_parallel": 17.696588998660445,
+        "linear_lif": 30.620184013969265
+      },
+      "peak_mem_mb": {
+        "lif_scan": 32.0019645690918,
+        "psu_parallel": 32.0019645690918,
+        "linear_lif": 32.5019645690918
+      },
+      "neuron_vs_matmul_fwd": 0.2118616902149051,
+      "neuron_vs_matmul_fwd_bwd": 0.46195471137423455,
+      "neuron_share_of_combined_fwd": 0.21023432728197208,
+      "parallel_speedup_scan_over_assoc": 1.1315132310000506,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 256,
+      "T": 1024,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 41.45310499006882,
+        "lif_scan": 9.858825505943969,
+        "psu_parallel": 20.731952507048845,
+        "linear_lif": 42.82989850617014
+      },
+      "fwd_bwd_ms": {
+        "linear": 73.24199100548867,
+        "lif_scan": 38.47675200086087,
+        "psu_parallel": 69.59558500966523,
+        "linear_lif": 108.74284050078131
+      },
+      "peak_mem_mb": {
+        "lif_scan": 128.0019645690918,
+        "psu_parallel": 128.0019645690918,
+        "linear_lif": 128.5019645690918
+      },
+      "neuron_vs_matmul_fwd": 0.23783080925556502,
+      "neuron_vs_matmul_fwd_bwd": 0.5253373300294016,
+      "neuron_share_of_combined_fwd": 0.23018559113614737,
+      "parallel_speedup_scan_over_assoc": 0.475537723839179,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 1024,
+      "T": 64,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 8.8556404953124,
+        "lif_scan": 1.7492559854872525,
+        "psu_parallel": 1.9684284925460815,
+        "linear_lif": 9.534870492643677
+      },
+      "fwd_bwd_ms": {
+        "linear": 29.66263449343387,
+        "lif_scan": 13.016053999308497,
+        "psu_parallel": 18.311737003386952,
+        "linear_lif": 39.930110491695814
+      },
+      "peak_mem_mb": {
+        "lif_scan": 32.0078239440918,
+        "psu_parallel": 32.0078239440918,
+        "linear_lif": 40.0078239440918
+      },
+      "neuron_vs_matmul_fwd": 0.1975301488823078,
+      "neuron_vs_matmul_fwd_bwd": 0.4388030335670196,
+      "neuron_share_of_combined_fwd": 0.1834588090983338,
+      "parallel_speedup_scan_over_assoc": 0.8886560990715296,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 1024,
+      "T": 256,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 34.87356250116136,
+        "lif_scan": 11.154020976391621,
+        "psu_parallel": 21.28321598866023,
+        "linear_lif": 37.2349820099771
+      },
+      "fwd_bwd_ms": {
+        "linear": 113.14111801038962,
+        "lif_scan": 36.18520399322733,
+        "psu_parallel": 70.37996799044777,
+        "linear_lif": 151.0324760020012
+      },
+      "peak_mem_mb": {
+        "lif_scan": 128.0078239440918,
+        "psu_parallel": 128.0078239440918,
+        "linear_lif": 136.0078239440918
+      },
+      "neuron_vs_matmul_fwd": 0.31984174189316533,
+      "neuron_vs_matmul_fwd_bwd": 0.3198236382099785,
+      "neuron_share_of_combined_fwd": 0.2995575766198277,
+      "parallel_speedup_scan_over_assoc": 0.5240759188994051,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    },
+    {
+      "H": 1024,
+      "T": 1024,
+      "batch": 64,
+      "fwd_ms": {
+        "linear": 134.38204849080648,
+        "lif_scan": 30.089578998740762,
+        "psu_parallel": 75.81470799050294,
+        "linear_lif": 164.59326251060702
+      },
+      "fwd_bwd_ms": {
+        "linear": 435.2553170028841,
+        "lif_scan": 150.9346369857667,
+        "psu_parallel": 263.11565599462483,
+        "linear_lif": 561.0445650090696
+      },
+      "peak_mem_mb": {
+        "lif_scan": 512.0078239440918,
+        "psu_parallel": 512.0078239440918,
+        "linear_lif": 520.0078239440918
+      },
+      "neuron_vs_matmul_fwd": 0.22391070337642077,
+      "neuron_vs_matmul_fwd_bwd": 0.3467726437555881,
+      "neuron_share_of_combined_fwd": 0.1828117295919186,
+      "parallel_speedup_scan_over_assoc": 0.3968831351630344,
+      "verdict_fwd": "MATMUL-BOUND \u2014 neuron kernel won't move wall-clock"
+    }
+  ]
+}


### PR DESCRIPTION
Part (a) of the Pallas-neurons investigation ([#24](https://github.com/kmheckel/spyx/issues/24)): **measure whether the neuron update is the bottleneck before writing a kernel.** A fused Pallas neuron kernel only pays off if the neuron scan — not the O(H²) `Linear` feeding it — dominates wall-clock.

`research/new/pallas_neurons/profile_neurons.py` is a `spyx.bench` component ablation (median latency, XLA-cost FLOPs, peak mem) isolating `Linear`-only vs sequential-`LIF` vs associative-scan-`PSU_LIF` vs the combined layer, swept over hidden width `H` and timesteps `T`.

## CPU findings (honest, device-caveated)
- **Matmul-bound in every forward regime** — the neuron scan is only **20–38%** of the `Linear`. A neuron kernel can't move forward wall-clock at these sizes.
- **Neuron approaches parity only in small-width (H=64) *training*** (fwd+bwd ~0.7–1.06×): the surrogate-grad scan backward matters most when the matmul is small — the narrow-net regime.
- **Associative-scan is not a free win** — the portable `PSU_LIF` parallel path beats the sequential scan only at small H, **loses up to 2.5× at large H·T**, and saves no memory. Its edge needs GPU parallel slack.
- **All CPU.** The #24 decision must be re-run on the 8060S / gfx1151 GPU, where higher matmul throughput raises the neuron's relative share — the crossover into neuron-bound territory can appear at trained sizes.

Research-only (no library/code changes). `profile_neurons.py` writes `profile_results.json` recording `backend`/`device`; the README carries the findings + the decision rule for whether part (b) (a fused kernel) is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)