### PR TITLE
feat(quant): NVFP4 / MXFP4 / MXFP8 microscaled quantization support

### DIFF
--- a/src/spyx/quant.py
+++ b/src/spyx/quant.py
@@ -90,10 +90,51 @@ def _require_qwix() -> Any:
     return _qwix
 
 
+# qwix's microscaled FP formats (``nvfp4`` / ``mxfp4`` / ``mxfp8``) attach a
+# small shared exponent to each contiguous block ("tile") of the quantized
+# axis, and qwix *enforces* a specific tile size per format - constructing a
+# rule with the wrong value raises ``ValueError: Format <fmt> requires a tile
+# size of <N>``. These are the required values (confirmed against qwix 0.1.8):
+# NVFP4 blocks 16 elements, the MX formats block 32.
+_MICROSCALED_TILE_SIZES = {"nvfp4": 16, "mxfp4": 32, "mxfp8": 32}
+
+
+def _default_tile_size(qtype: str | None) -> int | None:
+    """Return qwix's required tile size for a microscaled qtype, else ``None``.
+
+    ``nvfp4`` requires a tile size of ``16``; ``mxfp4`` and ``mxfp8`` require
+    ``32`` (qwix raises ``ValueError`` otherwise). Every other qtype - the
+    integer grids ``"int8"`` / ``"int4"`` / ``"int2"``, the plain floats, and
+    ``None`` - is not tiled and returns ``None``, so integer recipes keep their
+    historical ``tile_size=None`` behaviour untouched.
+    """
+    if qtype is None:
+        return None
+    return _MICROSCALED_TILE_SIZES.get(qtype)
+
+
+def _effective_tile_size(
+    tile_size: int | float | None,
+    weight_qtype: str | None,
+    act_qtype: str | None = None,
+) -> int | float | None:
+    """Resolve the tile size to hand qwix, auto-filling for microscaled formats.
+
+    An explicit ``tile_size`` always wins. When it is ``None`` we derive the
+    required value from ``weight_qtype`` (and fall back to ``act_qtype`` so an
+    activation-only microscaled setup still tiles correctly); for non-microscaled
+    qtypes this stays ``None`` and the produced rule is byte-identical to before.
+    """
+    if tile_size is not None:
+        return tile_size
+    return _default_tile_size(weight_qtype) or _default_tile_size(act_qtype)
+
+
 def linear_only_rules(
     weight_qtype: str | None = "int8",
     act_qtype: str | None = "int8",
     extra_op_names: Sequence[str] = (),
+    tile_size: int | float | None = None,
 ) -> list[Any]:
     """Quantize only the dense / conv layers of an SNN, leaving spiking dynamics alone.
 
@@ -103,10 +144,17 @@ def linear_only_rules(
     transforms and let the neurons run in fp32.
 
     :param weight_qtype: dtype string accepted by :class:`qwix.QuantizationRule`
-        (e.g. ``"int8"``, ``"int4"``, ``"fp8"``). ``None`` disables weight quant.
+        (e.g. ``"int8"``, ``"int4"``, ``"fp8"``, or the microscaled FP4/FP8
+        formats ``"nvfp4"`` / ``"mxfp4"`` / ``"mxfp8"``). ``None`` disables
+        weight quant.
     :param act_qtype: same options for activations. ``None`` disables.
     :param extra_op_names: additional op names to quantize alongside the default
         matmul / conv ops (e.g. a custom primitive).
+    :param tile_size: block size for the shared scale of microscaled formats. If
+        ``None`` (default) it is auto-filled from ``weight_qtype`` / ``act_qtype``
+        - ``16`` for ``"nvfp4"`` and ``32`` for ``"mxfp4"`` / ``"mxfp8"`` - which
+        are the values qwix requires; non-microscaled qtypes stay untiled. The
+        microscaled path is emulated on CPU / ROCm and accelerates on Blackwell.
     :return: a single-element list with a qwix :class:`QuantizationRule`.
 
     .. note::
@@ -124,12 +172,14 @@ def linear_only_rules(
     """
     qwix = _require_qwix()
     op_names = ("dot_general", "conv_general_dilated", *extra_op_names)
+    tile_size = _effective_tile_size(tile_size, weight_qtype, act_qtype)
     return [
         qwix.QuantizationRule(
             module_path=".*",
             op_names=op_names,
             weight_qtype=weight_qtype,
             act_qtype=act_qtype,
+            tile_size=tile_size,
         )
     ]
 
@@ -138,6 +188,7 @@ def weights_only_rules(
     weight_qtype: str = "int8",
     module_path: str = ".*",
     op_names: Sequence[str] = ("dot_general", "conv_general_dilated"),
+    tile_size: int | float | None = None,
 ) -> list[Any]:
     """Quantize only the weights, leaving activations in fp32.
 
@@ -147,14 +198,29 @@ def weights_only_rules(
     Selects work by op name rather than module class — see
     :func:`linear_only_rules` for why (qwix ``module_path`` matches the NNX
     attribute path, not the class name).
+
+    :param weight_qtype: dtype string for the weights. Integer grids (``"int8"``
+        / ``"int4"`` / ``"int2"``) and the microscaled FP formats ``"nvfp4"`` /
+        ``"mxfp4"`` / ``"mxfp8"`` are all accepted.
+    :param module_path: qwix ``module_path`` regex (matched against the NNX
+        attribute path, *not* the class name).
+    :param op_names: ops to quantize; defaults to the dense / conv feedforward
+        transforms.
+    :param tile_size: block size for the shared scale of microscaled formats. If
+        ``None`` (default) it is auto-filled from ``weight_qtype`` - ``16`` for
+        ``"nvfp4"`` and ``32`` for ``"mxfp4"`` / ``"mxfp8"``, the values qwix
+        requires; integer qtypes stay untiled. The microscaled path is emulated
+        on CPU / ROCm and accelerates on Blackwell.
     """
     qwix = _require_qwix()
+    tile_size = _effective_tile_size(tile_size, weight_qtype)
     return [
         qwix.QuantizationRule(
             module_path=module_path,
             op_names=tuple(op_names),
             weight_qtype=weight_qtype,
             act_qtype=None,
+            tile_size=tile_size,
         )
     ]
 
@@ -164,6 +230,7 @@ def spiking_feedforward_rules(
     *,
     module_path: str = ".*",
     extra_op_names: Sequence[str] = (),
+    tile_size: int | float | None = None,
 ) -> list[Any]:
     """Weight-only quantization of the ``spike -> Linear`` feedforward path.
 
@@ -190,24 +257,32 @@ def spiking_feedforward_rules(
     recurrent path requires.
 
     :param weight_qtype: dtype string for the feedforward weights (``"int8"``
-        default; ``"int4"`` / ``"int2"`` for more compression). Activations are
-        never quantized here.
+        default; ``"int4"`` / ``"int2"`` for more compression, or the microscaled
+        ``"nvfp4"`` / ``"mxfp4"`` / ``"mxfp8"`` FP formats). Activations are never
+        quantized here.
     :param module_path: qwix ``module_path`` regex (matched against the NNX
         attribute path, *not* the class name - see :func:`linear_only_rules`).
     :param extra_op_names: additional feedforward op names to quantize. Do
         **not** add ``"einsum"`` unless you intend to quantize the recurrent
         path (which Q-S5 advises against).
+    :param tile_size: block size for the shared scale of microscaled formats. If
+        ``None`` (default) it is auto-filled from ``weight_qtype`` - ``16`` for
+        ``"nvfp4"`` and ``32`` for ``"mxfp4"`` / ``"mxfp8"``, the values qwix
+        requires; integer qtypes stay untiled. The microscaled path is emulated
+        on CPU / ROCm and accelerates on Blackwell.
     :return: a single-element list with a weight-only qwix
         :class:`QuantizationRule`.
     """
     qwix = _require_qwix()
     op_names = ("dot_general", "conv_general_dilated", *extra_op_names)
+    tile_size = _effective_tile_size(tile_size, weight_qtype)
     return [
         qwix.QuantizationRule(
             module_path=module_path,
             op_names=op_names,
             weight_qtype=weight_qtype,
             act_qtype=None,
+            tile_size=tile_size,
         )
     ]
 

--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -312,6 +312,32 @@ def test_feedforward_quant_is_not_a_silent_noop():
 
 
 @needs_qwix
+@pytest.mark.parametrize("weight_qtype", ["nvfp4", "mxfp4"])
+def test_microscaled_fp4_quant_is_not_a_silent_noop(weight_qtype):
+    """Microscaled FP4 weight-only rules auto-fill tile_size and really quantize.
+
+    The ``nvfp4`` / ``mxfp4`` formats need a per-format ``tile_size`` (16 / 32)
+    that qwix enforces; the builders auto-fill it from the qtype. This mirrors
+    :func:`test_feedforward_quant_is_not_a_silent_noop` for the FP4 path:
+    weight-only (``act_qtype=None``), CPU-emulated, and the quantized output
+    must differ measurably from the full-precision matmul.
+    """
+    rngs = nnx.Rngs(0)
+    # Contraction axis (32) is divisible by both required tile sizes (16, 32).
+    lin = nnx.Linear(32, 8, use_bias=False, rngs=rngs)
+    W = jnp.asarray(lin.kernel.value, dtype=jnp.float32)
+
+    rules = spyx.quant.weights_only_rules(weight_qtype=weight_qtype)
+    assert rules[0].act_qtype is None
+    expected_tile = {"nvfp4": 16, "mxfp4": 32}[weight_qtype]
+    assert rules[0].tile_size == expected_tile
+
+    x = jax.random.uniform(jax.random.PRNGKey(4), (4, 32))
+    qmodel = spyx.quant.quantize(lin, x, rules=rules, mode="ptq")
+    assert float(jnp.max(jnp.abs(qmodel(x) - x @ W))) > 1e-4
+
+
+@needs_qwix
 def test_spiking_feedforward_leaves_recurrent_einsum_in_fp32():
     """A recurrent einsum weight stays fp32 while the feedforward kernel is int8."""
 


### PR DESCRIPTION
qwix supports the microscaled FP formats (`nvfp4`/`mxfp4`/`mxfp8`) but requires a per-format `tile_size` — `nvfp4`→16, `mxfp4`/`mxfp8`→32 — that the spyx rule builders didn't expose, so `spyx.quant.weights_only_rules(weight_qtype="nvfp4")` failed at `quantize()` with a *"requires tiled_axes"* error.

## Change
- Adds a `tile_size` param (default `None`) to `linear_only_rules`, `weights_only_rules`, `spiking_feedforward_rules`. When `None`, it **auto-fills** the qwix-required value from the weight (or activation) qtype via `_default_tile_size`; an explicit `tile_size` always wins.
- **Strict backward compat:** integer/existing qtypes stay untiled → byte-identical rules and behavior. Existing callers/tests unaffected.
- Docstrings document the FP4/FP8 formats + auto tile size, and note the microscaled path emulates on CPU/ROCm and accelerates on Blackwell.

## Test
`test_microscaled_fp4_quant_is_not_a_silent_noop` (parametrized nvfp4/mxfp4): asserts the builder auto-fills the right `tile_size`, `act_qtype is None`, and the quantized output actually differs (`max|fp-q| > 1e-4`) — a real guard (fails if the tile wiring is removed).

Built and adversarially verified via workflow: ruff + ty clean; `tests/test_quant.py` **21 passed, 1 skipped**. Backward compat confirmed (int8 default → `tile_size=None`, delta 0.006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)