### PR TITLE
research: agentic-research process (backlog + findings ledger + promotion gate)

### DIFF
--- a/.claude/skills/promote-finding.md
+++ b/.claude/skills/promote-finding.md
@@ -1,0 +1,43 @@
+---
+name: promote-finding
+description: Promote a research finding up the Spyx ladder (research → spyx.experimental → stable core). Use when the user decides to promote a study, says "graduate this", "move X into experimental/core", or "run the promotion checklist". Runs the PROMOTION.md gate and stages the promotion PR — the human still decides.
+---
+
+# Promote a finding
+
+The human has decided a `research/` finding earns a home in the library. Your job is
+to **run the gate checklist, extract the API cleanly, and stage a PR** — not to
+decide. Read `research/PROMOTION.md` (the criteria) and `research/FINDINGS.md` (the
+study's row) first, and confirm which rung: `research → experimental` or
+`experimental → core`.
+
+## Steps
+
+1. **Confirm the target and the study.** Which study, which rung. If the study's
+   Findings are still smoke-only or PENDING, **stop** — it is not promotable yet; say
+   what run is missing.
+2. **Run the checklist** for the target rung from `research/PROMOTION.md`. Report each
+   item pass/fail with evidence. If any fails, stop and list what is missing.
+3. **Extract the API** (only if the checklist passes):
+   - *To `spyx.experimental`:* create/extend the owning module under
+     `src/spyx/experimental/`, lift the minimal reusable surface out of the study
+     script, export it from `spyx/experimental/__init__.py`, and add unit tests under
+     `tests/` (not network-gated). Keep the study folder as the provenance record.
+   - *To stable core:* move the symbol into the owning core module (`spyx.nn` / `ssm`
+     / `quant` / …), add reference + explanation/how-to docs, update the **stable-core
+     list in `CLAUDE.md` and `AGENTS.md`**, and add a deprecation note if it replaces
+     something.
+4. **Verify locally:** `uv run pytest -m "not network"`, `uv run ruff check`,
+   `uv run ty check`, and (for core) `uv run mkdocs build --strict`. All must pass.
+5. **Update the ledger.** Flip the study's Status in `research/FINDINGS.md` to
+   `experimental` or `core` and note the landing module.
+6. **Stage the PR** (branch + push + open PR) with the checklist results in the body.
+   **Do not merge** — the human reviews and merges. Promotion is their signature.
+
+## Guardrails
+
+- Do not promote a ❌ or ➖ finding, or one whose Findings are smoke-only/PENDING.
+- Do not change the finding's verdict to justify promotion.
+- Experimental keeps the unstable-API contract; only core promotion implies support.
+- If extraction would require reshaping the result or weakening a test to pass, stop
+  and report — the finding is not ready.

--- a/.claude/skills/research-study.md
+++ b/.claude/skills/research-study.md
@@ -1,0 +1,58 @@
+---
+name: research-study
+description: Run one Spyx research study end-to-end, unattended. This is the playbook the scheduled Claude Code (web) research task follows each run — it pulls the next item from research/BACKLOG.md, builds and adversarially verifies a study, opens a PR, and stops at the human gate. Also usable interactively when the user says "run a research study" or "pick up the backlog".
+---
+
+# Run one research study (unattended)
+
+You are the **scheduled agentic researcher** for Spyx. Each run does **exactly one
+study**, produces a **PR + a ledger row for human review**, and stops. You never
+promote, never touch stable core, never merge. Read `research/README.md`,
+`research/PROMOTION.md`, and `research/FINDINGS.md` first.
+
+## The loop (one run)
+
+1. **Pick work.** Open `research/BACKLOG.md`. Take the **highest-priority `ready`**
+   item. If none is `ready`, stop and report "backlog empty" — do not invent work.
+2. **Claim it.** Create a branch `research/<study-slug>`. Mark the item
+   `claimed: research/<study-slug>` in `BACKLOG.md` on that branch.
+3. **Scaffold.** Copy `research/_template/` into `research/new/<study-slug>/`. Fill
+   the README contract (Title, Claim under test, Method, Honest expected outcome,
+   How to run, Findings=PENDING, Reproducibility). State the one falsifiable claim.
+4. **Build + verify with a workflow.** Use the Workflow tool to run: **implement**
+   the study script (self-contained, `SPYX_SMOKE=1` synthetic-data mode, writes a
+   results JSON) → **adversarially verify** (an independent agent that runs the
+   smoke, checks the quantization/mechanism is genuine, and audits for fabricated
+   numbers). Iterate until the smoke runs clean and the verifier returns PASS. This
+   mirrors the repo's established pattern (see `research/new/quant_aware_evolution/`).
+5. **Report honestly.** Fill the README Findings **only from what the smoke shows**,
+   and label it plumbing-only if the budget is too small to conclude. If the claim
+   needs a full/GPU/dataset run to settle, write "Findings: PENDING full run" and say
+   exactly what run is required. **Never fabricate or reshape a result.**
+6. **Open the gate artifact.** Push the branch, open a **draft PR** (title
+   `research: <study-slug>`), append a row to `research/FINDINGS.md` (verdict ⏳ or
+   the smoke-only verdict; status `new`), and set the backlog item to `in-review: #<pr>`.
+7. **Stop.** Report the PR link and what a human must do next (review; run the flagged
+   full/GPU step; decide on promotion). End the run.
+
+## Hard stops (autonomy safety — never cross these unattended)
+
+- **Never edit `src/spyx/` stable core** or `tests/` for core. Studies live only under
+  `research/`. (Enabling library changes, e.g. a new `spyx.quant` format, is a
+  *separate* human-reviewed PR — put the need in the PR description, don't do it here.)
+- **Never run GPU, full-budget, or dataset-downloading steps.** Smoke/synthetic/CPU
+  only. If the claim needs one, flag it for a human in the PR — do not run it.
+- **Never promote** (research → experimental → core) and **never merge** a PR. That is
+  the human gate (`research/PROMOTION.md`).
+- **Never turn a ❌/➖ into a ✅.** Negatives are the point; record them straight.
+- **One item per run.** Do not batch the backlog.
+- If anything is ambiguous or a hard stop would be needed to proceed, **stop and leave
+  a note in the PR** rather than guessing.
+
+## Setup (the schedule itself)
+
+Run this as a **scheduled task in Claude Code on the web** pointed at the Spyx repo,
+firing this skill (e.g. daily/weekly). Each firing is one loop above. The cadence is
+yours; the runner self-limits to one study per firing, so the queue drains at one
+study per tick and every result waits for you in a PR + the ledger. Keep the backlog
+seeded — an empty backlog just makes the run a no-op.

--- a/research/BACKLOG.md
+++ b/research/BACKLOG.md
@@ -1,0 +1,46 @@
+# Research backlog
+
+The queue the **scheduled agentic runner** pulls from (see the
+[research-study skill](../.claude/skills/research-study.md)). Each run picks the
+**top unblocked, unclaimed** item, does one study, opens a PR, and stops for review.
+
+**State:** `ready` (pick me) · `claimed: <branch>` (a run is on it) · `in-review: #<pr>`
+(PR open, awaiting you) · `done` (merged) · `blocked: <why>`. Ordered by priority;
+the runner takes the highest `ready` item. Add items freely — one claim per item.
+
+## Active track: quantization & efficient architectures
+
+1. **`ready` — Hard-task quantization-aware evolution.** The
+   [quant_aware_evolution](new/quant_aware_evolution/) null result came from an easy
+   task (every precision hit ~100%). Re-run ES-vs-STE-QAT on a **capacity-constrained**
+   setup where nvfp4/ternary actually *degrades* accuracy — real SHD (20 classes, 128
+   channels, long T) with a tight hidden width. Claim: the STE-bias gap appears (ES
+   ahead) only once quantization costs accuracy. *Note: build + smoke only; flag the
+   full SHD/GPU run for a human (needs the ROCm venv + dataset).*
+
+2. **`ready` — matfree vs NVFP4 at matched footprint.** Quantify the
+   [substrate-doc](../docs/explanation/substrate-and-the-hardware-lottery.md) claim:
+   ternary (~1.58-bit) vs NVFP4 (~4-bit) weight quality at matched *memory footprint*
+   and at matched *bit-width*, on a small classifier. Claim: NVFP4 wins accuracy at
+   equal bits; ternary wins footprint. Uses `spyx.quant` (both formats now supported).
+
+3. **`ready` — NVFP4 on the binary spike→Linear path.** Because spikes are binary,
+   quantizing weights adds no activation-side error. Measure NVFP4-weight QAT accuracy
+   vs int8 vs fp32 on a spiking classifier via `spyx.quant.spiking_feedforward_rules`
+   extended to nvfp4. Claim: the binary-spike quant win holds at 4-bit float.
+
+## Other candidate questions
+
+4. **`ready` — Widen the portable `.parallel` path.** The
+   [pallas_neurons](new/pallas_neurons/) finding was "use associative_scan, not a
+   kernel." Survey which neuron types (CuBaLIF, ALIF) can be linearized into an
+   associative-scan `.parallel` method, and prototype one. Claim: N more neurons get
+   the 2–21× GPU speedup with no accuracy loss.
+
+## Conventions for items
+
+- One item = one falsifiable claim. Keep it small enough for a single study.
+- Prefer self-contained synthetic-task smoke validation; mark any dataset-download or
+  GPU/full-budget step as **human-gated** — the unattended runner must not do it.
+- When an item is `done`, leave it here struck through for one cycle, then move its
+  outcome to [FINDINGS.md](FINDINGS.md).

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -1,0 +1,48 @@
+# Findings ledger
+
+The single review surface for research done with Spyx. Every study lands a row
+here; the **Status** column is the promotion gate — see [PROMOTION.md](PROMOTION.md)
+for the rungs and criteria. Agents append rows and keep verdicts honest; **only a
+human flips Status** (research → experimental → core).
+
+**Verdict:** ✅ positive · ➖ null / parity · ❌ negative · ⏳ in progress.
+**Status:** `new` (in `research/`) · `experimental` (landed in `spyx.experimental`) ·
+`core` (stable API) · `archived`.
+
+> **Honest negatives are first-class.** A ❌ or ➖ is a *result*, not a failure. It
+> stays in `research/` permanently so the question is not re-litigated. It is never
+> deleted, and never reshaped into a positive to justify promotion.
+
+## Active track: quantization & efficient architectures
+
+The current focus. Studies probing low-precision (NVFP4/MXFP4, ternary),
+matmul-free layers, SSMs, and the training methods that fit them.
+
+| Study | Claim (short) | Verdict | Status | Landed in / next |
+| --- | --- | --- | --- | --- |
+| [ternary_llm](new/ternary_llm/) | BitNet-ternary QAT path generalizes from spiking nets to transformers | ✅ | experimental | `spyx.experimental.matfree` |
+| [quant_aware_evolution](new/quant_aware_evolution/) | Gradient-free ES beats STE-QAT at extreme precision (no STE bias) | ➖ | new | null on easy task; needs a hard, capacity-constrained task |
+| [hybrid_evo_surrogate](new/hybrid_evo_surrogate/) | Orthogonal-ES correction / SGES beats surrogate on the hard-spike loss | ➖ | experimental | `spyx.experimental.hybrid` (safe, not a win — needs large-bias regime) |
+| [pallas_neurons](new/pallas_neurons/) | A fused Pallas neuron kernel is worth building (#24) | ❌ | new | matmul-bound; `associative_scan` already gives 2–21× portably |
+
+## Other studies
+
+| Study | Claim (short) | Verdict | Status | Landed in / next |
+| --- | --- | --- | --- | --- |
+| [parallel_spiking_neurons](new/parallel_spiking_neurons/) | Reset-free / R&F neurons parallelize the time loop with no accuracy loss | ✅ | core | `spyx.nn.PSU_LIF`, `spyx.phasor.ResonateFire` |
+| [raven_sparse_memory_recall](new/raven_sparse_memory_recall/) | Routing-slot memory beats a diagonal SSM on recall | ✅ (modest) | experimental | `spyx.experimental.raven` (regime-dependent) |
+| [ssm_to_spiking_transfer](new/ssm_to_spiking_transfer/) | R&F *is* a thresholded S5Diag; transferring SSM dynamics helps spiking | ➖ | new | equivalence exact; S5Diag still beats the spiking variant |
+| [pretrain_finetune_curriculum](new/pretrain_finetune_curriculum/) | A pretrain→finetune curriculum lifts spiking accuracy | ❌ | new | honest negative; boundary condition recorded |
+
+## How to read / update this
+
+- **Adding a study (agent):** append a row with verdict ⏳ while running, then the
+  real verdict once the study's README Findings are filled from a real run. Link the
+  study folder. Do not invent numbers.
+- **Promoting (human):** when you decide a `new` finding earns a home in the library,
+  run [`/promote-finding`](../.claude/skills/promote-finding.md) — it walks the
+  [PROMOTION.md](PROMOTION.md) checklist and, on your go-ahead, extracts the API +
+  tests + docs and flips the Status here.
+- **Starting a study (agent):** [`/research-study`](../.claude/skills/research-study.md)
+  scaffolds and adversarially verifies a new study, then stops at this ledger for your
+  review — it never promotes on its own.

--- a/research/PROMOTION.md
+++ b/research/PROMOTION.md
@@ -1,0 +1,60 @@
+# Promotion gate
+
+How a finding moves from a `research/` study into the library. The ladder is
+deliberately slow: research is cheap and disposable, `spyx.experimental` is a
+promise of "tested and usable", and stable core is a promise of "supported API".
+**Every rung up is a human decision** — agents prepare, they do not promote.
+
+## The ladder
+
+```
+research/new/          any honest study (positive, negative, or null)
+      │  ── human gate 1 ──▶
+spyx.experimental.*     a useful finding with a minimal, tested API
+      │  ── human gate 2 ──▶
+stable core             a stable, documented, fully-tested API
+```
+
+Honest **negatives and nulls stop at `research/`** — they are recorded in
+[FINDINGS.md](FINDINGS.md) and kept forever so the question is not re-litigated.
+They are never promoted and never deleted.
+
+## Gate 1 — `research/` → `spyx.experimental`
+
+Promote when a study lands a **useful, reusable** result. Checklist:
+
+- [ ] The study README Findings are filled from a **real run** (not smoke), with
+      numbers and seed spread — and the verdict is genuinely ✅ (or a ➖ with a
+      clearly useful artifact, e.g. a working primitive).
+- [ ] The result was **adversarially verified** (an independent pass that tried to
+      refute it — correctness *and* honesty).
+- [ ] A **minimal API** can be extracted (one module / a few functions or a class),
+      importable from `spyx.experimental`.
+- [ ] **Unit tests** added under `tests/` covering the new surface; not network-gated.
+- [ ] **No stable-core API change** and no new hard dependency on unmerged work.
+- [ ] `uv run pytest -m "not network"`, `ruff`, and `ty` all green.
+- [ ] Row in [FINDINGS.md](FINDINGS.md) updated to `experimental` with the landing module.
+
+## Gate 2 — `spyx.experimental` → stable core
+
+Promote when the experimental API has proven itself and you are ready to support it.
+
+- [ ] API reviewed and judged **stable** (naming, signature, the `(x, state) ->
+      (out, new_state)` contract for neurons / layers).
+- [ ] **Full test coverage** including edge cases, on CPU (and ideally a GPU spot-check).
+- [ ] **Reference docs** (`docs/reference/`) and at least one **explanation** or
+      how-to page; `mkdocs build --strict` green.
+- [ ] Moved out of `spyx.experimental` into the owning core module; the
+      **stable-core list** in `CLAUDE.md` and `AGENTS.md` updated.
+- [ ] CI green on **all** supported Python versions; `ty` clean.
+- [ ] A **deprecation note** for anything it replaces, if applicable.
+- [ ] [FINDINGS.md](FINDINGS.md) row flipped to `core`.
+
+## Who does what
+
+- **Agents** (incl. the scheduled runner, see [research-study skill](../.claude/skills/research-study.md))
+  produce studies + ledger rows + PRs, and — when you ask — run the checklist and
+  prepare the promotion PR. They **stop at every gate**.
+- **You** review the PR, decide, and merge. Promotion is your signature, not the
+  agent's. Use [`/promote-finding`](../.claude/skills/promote-finding.md) to have an
+  agent run the checklist and stage the promotion PR for that decision.

--- a/research/README.md
+++ b/research/README.md
@@ -29,6 +29,26 @@ Every study is a self-contained folder that copies [`_template/README.md`](_temp
 and fills it in. That template is the contract: Title, Paper, Claim under test,
 Method, Spyx modules used, How to run, Results table, Findings, Reproducibility.
 
+## Process (agentic research + promotion gate)
+
+Research here runs on a loop with a human gate:
+
+- **[BACKLOG.md](BACKLOG.md)** — the queue of falsifiable claims to study. Current
+  focus track: **quantization & efficient architectures.**
+- **[FINDINGS.md](FINDINGS.md)** — the ledger: every study's honest verdict and its
+  promotion status. Your review surface.
+- **[PROMOTION.md](PROMOTION.md)** — the gate: criteria for `research →
+  spyx.experimental → core`. Every rung up is a human decision.
+- **[`/research-study`](../.claude/skills/research-study.md)** — the unattended runner
+  (a scheduled Claude Code web task): pulls the top backlog item, builds and
+  adversarially verifies one study, opens a PR + ledger row, and **stops at the gate**
+  — never edits core, never runs GPU/full budgets, never promotes.
+- **[`/promote-finding`](../.claude/skills/promote-finding.md)** — you invoke this when
+  you decide to graduate a finding; it runs the checklist and stages the promotion PR.
+
+Honest negatives and nulls are first-class: they stay in `research/`, indexed in the
+ledger, and are never deleted or reshaped.
+
 ## Index of existing work
 
 The material already in this directory maps onto the taxonomy as follows. Nothing


### PR DESCRIPTION
Scaffolding for **scheduled/unattended agentic research with a human promotion gate**, on top of the existing `research/` taxonomy. Assumes the runner is **Claude Code on the web as a scheduled task**.

## The structure
- **`research/BACKLOG.md`** — queue of falsifiable claims. Focus track: *quantization & efficient architectures*; seeded with this session's next-steps (hard-task quant-aware-evolution, matfree-vs-NVFP4 at matched footprint, NVFP4 on the binary spike→Linear path, widening the portable `.parallel` path).
- **`research/FINDINGS.md`** — the review-surface **ledger**: every study's honest verdict (✅/➖/❌/⏳) + promotion status (`new`/`experimental`/`core`). Pre-populated from the 8 existing studies. **Honest negatives are first-class** — never deleted or reshaped.
- **`research/PROMOTION.md`** — the **gate**: explicit checklists for `research → spyx.experimental → core`. Every rung up is a human decision.
- **`.claude/skills/research-study.md`** — the **unattended runner playbook**: pulls the top backlog item, scaffolds from the template, builds + adversarially verifies one study via a Workflow, opens a **PR + ledger row**, and **stops**. Hard stops for autonomy safety: never edits `src/spyx/` core, never runs GPU/full/dataset budgets, never promotes or merges, never reshapes a ❌/➖. One study per run.
- **`.claude/skills/promote-finding.md`** — the **human-invoked gate**: runs the promotion checklist, extracts the API + tests + docs, stages the promotion PR (you decide/merge).

## The loop
scheduled web task → picks backlog item → study + smoke-verify → **draft PR + ⏳ ledger row** → *you* review/merge, run any flagged full/GPU step, and `/promote-finding` when it earns a home.

Docs + skills only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)