### PR TITLE
research: literature scout + local-loop (AMD GPU) runner mode

### DIFF
--- a/.claude/skills/research-scout.md
+++ b/.claude/skills/research-scout.md
@@ -1,0 +1,49 @@
+---
+name: research-scout
+description: Survey current literature and propose Spyx research backlog items, classified as replication / extension / novelty. Use when the user says "scout papers", "what should we research next", "find replication targets", or when the backlog is running low. Feeds research/BACKLOG.md candidates for human triage.
+---
+
+# Scout the literature → backlog candidates
+
+Turn the current state of the field into **falsifiable, Spyx-shaped backlog items**.
+You research against real papers and classify each opportunity onto the repo's
+taxonomy (see `research/README.md`): **replication**, **extension**, or **novelty**.
+You propose; the human triages. Read `research/BACKLOG.md` and `research/FINDINGS.md`
+first so you don't re-propose done or in-flight work.
+
+## Steps
+
+1. **Pick a focus.** Default to the active track in `research/BACKLOG.md`
+   (quantization & efficient architectures: low-precision training — NVFP4/MXFP4,
+   ternary/BitNet, shift-add; SSMs; matmul-free; spiking efficiency). Or take the
+   user's topic.
+2. **Search real work** with WebSearch / WebFetch — recent arXiv, top venues, and the
+   primary sources behind claims (do not rely on memory for anything post-cutoff or
+   for specific numbers). Shortlist ~5–10 papers with links and dates.
+3. **Classify each into one falsifiable opportunity:**
+   - **Replication** — a headline claim you can reproduce in Spyx and check whether it
+     holds (and how it compares to Spyx's existing methods). Best when the claim is a
+     specific number/trend on a task Spyx can express.
+   - **Extension** — a published method pushed somewhere new: a Spyx neuron/SSM/quant
+     format it hasn't been tried with, a scaling sweep, an ablation, a harder task.
+   - **Novelty** — a gap the paper exposes but does not fill, that Spyx's primitives
+     are unusually suited to (e.g. binary-spike × low-precision weights; gradient-free
+     ES on a non-differentiable objective the paper trains with STE).
+4. **Assess fit and cost honestly:** does Spyx already have the pieces? Can it be a
+   self-contained synthetic-smoke study, or does it need a dataset / GPU / full budget
+   (which is human-gated for the unattended runner)? Prefer small, decisive claims.
+5. **Propose candidates.** Append to the **Candidates** section of
+   `research/BACKLOG.md`, one item each: a one-line falsifiable claim, the paper
+   (title + link + year), the bucket (replication/extension/novelty), the Spyx
+   modules involved, and the rough cost / whether a GPU run is needed. Do **not**
+   promote candidates to `ready` — that is the human's triage.
+
+## Guardrails
+
+- **Cite real, findable sources** (title + link + venue/year). Never invent a paper,
+  a number, or a claim. Mark clearly what the paper *claims* vs what the study would
+  *test* — they are not the same.
+- Flag when a claim is contested or when reproduction is known to be hard.
+- Do not start studies here — scouting only fills the backlog. The
+  [`/research-study`](research-study.md) runner picks up from there.
+- Keep proposals small and falsifiable; a vague "explore X" is not a backlog item.

--- a/.claude/skills/research-study.md
+++ b/.claude/skills/research-study.md
@@ -5,10 +5,28 @@ description: Run one Spyx research study end-to-end, unattended. This is the pla
 
 # Run one research study (unattended)
 
-You are the **scheduled agentic researcher** for Spyx. Each run does **exactly one
-study**, produces a **PR + a ledger row for human review**, and stops. You never
-promote, never touch stable core, never merge. Read `research/README.md`,
-`research/PROMOTION.md`, and `research/FINDINGS.md` first.
+You are the **agentic researcher** for Spyx. Each run does **exactly one study**,
+produces a **PR + a ledger row for human review**, and stops. You never promote,
+never touch stable core, never merge. Read `research/README.md`,
+`research/PROMOTION.md`, `research/BACKLOG.md`, and `research/FINDINGS.md` first.
+Backlog low? Run [`/research-scout`](research-scout.md) first to propose candidates.
+
+## Two runner modes
+
+Detect which you are and set the experiment budget accordingly:
+
+- **Scheduled web** (Claude Code on the web, cron) — **no GPU**. Smoke / synthetic /
+  CPU only. If a claim needs a real run, write "Findings: PENDING full run", say
+  exactly what run is required, and flag it for a human. Never download datasets.
+- **Local loop** (Claude Code on the AMD box, e.g. `/loop`) — **has the ROCm GPU**
+  (`~/.venvs/jax-rocm-0.9.2/bin/python`, gfx1151; see the strix-halo setup). You MAY
+  run **bounded small-scale real experiments** so Findings can be *real, not pending*:
+  time-box to roughly ≤10–15 min, a reduced sweep (e.g. 1–3 seeds, modest pop/gens),
+  and record the device. Anything bigger (multi-hour, large sweep, big dataset
+  download) is still human-gated — say so and stop. Install missing deps into the
+  ROCm venv with `--no-deps` (it is pinned; a plain install can clobber the +rocm jax).
+
+Everything else below is identical across modes. The gate does not move.
 
 ## The loop (one run)
 
@@ -25,10 +43,12 @@ promote, never touch stable core, never merge. Read `research/README.md`,
    smoke, checks the quantization/mechanism is genuine, and audits for fabricated
    numbers). Iterate until the smoke runs clean and the verifier returns PASS. This
    mirrors the repo's established pattern (see `research/new/quant_aware_evolution/`).
-5. **Report honestly.** Fill the README Findings **only from what the smoke shows**,
-   and label it plumbing-only if the budget is too small to conclude. If the claim
-   needs a full/GPU/dataset run to settle, write "Findings: PENDING full run" and say
-   exactly what run is required. **Never fabricate or reshape a result.**
+5. **Report honestly.** Fill the README Findings from what you actually ran — smoke
+   only (web mode) or a bounded real run (local-loop mode), labelled with the device
+   and budget. If the budget was too small to conclude, say plumbing-only; if the
+   claim still needs a bigger human-gated run, write "Findings: PENDING full run" and
+   say exactly what is required. **Never fabricate or reshape a result**, and never
+   present a smoke/under-budget number as a conclusion.
 6. **Open the gate artifact.** Push the branch, open a **draft PR** (title
    `research: <study-slug>`), append a row to `research/FINDINGS.md` (verdict ⏳ or
    the smoke-only verdict; status `new`), and set the backlog item to `in-review: #<pr>`.
@@ -40,8 +60,10 @@ promote, never touch stable core, never merge. Read `research/README.md`,
 - **Never edit `src/spyx/` stable core** or `tests/` for core. Studies live only under
   `research/`. (Enabling library changes, e.g. a new `spyx.quant` format, is a
   *separate* human-reviewed PR — put the need in the PR description, don't do it here.)
-- **Never run GPU, full-budget, or dataset-downloading steps.** Smoke/synthetic/CPU
-  only. If the claim needs one, flag it for a human in the PR — do not run it.
+- **Respect the mode budget for experiments.** Scheduled-web: smoke/synthetic/CPU
+  only. Local-loop: bounded small-scale GPU runs are allowed (≤~15 min, reduced
+  sweep); anything larger — multi-hour runs, big sweeps, dataset downloads — is
+  human-gated in both modes. Flag it in the PR; do not run it.
 - **Never promote** (research → experimental → core) and **never merge** a PR. That is
   the human gate (`research/PROMOTION.md`).
 - **Never turn a ❌/➖ into a ✅.** Negatives are the point; record them straight.
@@ -49,10 +71,15 @@ promote, never touch stable core, never merge. Read `research/README.md`,
 - If anything is ambiguous or a hard stop would be needed to proceed, **stop and leave
   a note in the PR** rather than guessing.
 
-## Setup (the schedule itself)
+## Setup
 
-Run this as a **scheduled task in Claude Code on the web** pointed at the Spyx repo,
-firing this skill (e.g. daily/weekly). Each firing is one loop above. The cadence is
-yours; the runner self-limits to one study per firing, so the queue drains at one
-study per tick and every result waits for you in a PR + the ledger. Keep the backlog
-seeded — an empty backlog just makes the run a no-op.
+Either driver works; both fire this skill and self-limit to one study per run, so the
+queue drains one study per tick and every result waits for you in a PR + the ledger:
+
+- **Scheduled web** — a scheduled task in Claude Code on the web pointed at the Spyx
+  repo (e.g. daily/weekly). Smoke-only; good for breadth and for staging GPU work.
+- **Local loop** — Claude Code on the AMD box in a loop (e.g. `/loop`), leveraging the
+  gfx1151 GPU for bounded real runs. Good for landing *real* small-scale findings.
+
+Keep the backlog seeded (via [`/research-scout`](research-scout.md) or by hand) — an
+empty backlog just makes the run a no-op.

--- a/research/BACKLOG.md
+++ b/research/BACKLOG.md
@@ -1,12 +1,18 @@
 # Research backlog
 
-The queue the **scheduled agentic runner** pulls from (see the
+The queue the **agentic runner** pulls from (see the
 [research-study skill](../.claude/skills/research-study.md)). Each run picks the
 **top unblocked, unclaimed** item, does one study, opens a PR, and stops for review.
 
 **State:** `ready` (pick me) · `claimed: <branch>` (a run is on it) · `in-review: #<pr>`
 (PR open, awaiting you) · `done` (merged) · `blocked: <why>`. Ordered by priority;
 the runner takes the highest `ready` item. Add items freely — one claim per item.
+
+**Bucket** (the taxonomy in [README.md](README.md)): `replication` (reproduce a
+paper's claim in Spyx) · `extension` (push a method somewhere new) · `novelty` (a gap
+Spyx is suited to fill). [`/research-scout`](../.claude/skills/research-scout.md)
+proposes buckets from the literature into **Candidates** below; you triage them to
+`ready`.
 
 ## Active track: quantization & efficient architectures
 
@@ -36,6 +42,12 @@ the runner takes the highest `ready` item. Add items freely — one claim per it
    kernel." Survey which neuron types (CuBaLIF, ALIF) can be linearized into an
    associative-scan `.parallel` method, and prototype one. Claim: N more neurons get
    the 2–21× GPU speedup with no accuracy loss.
+
+## Candidates (from scouting — triage before promoting to `ready`)
+
+Proposed by [`/research-scout`](../.claude/skills/research-scout.md) from the
+literature; each carries a paper link + bucket. **Not picked up by the runner until
+you move one to a numbered `ready` item above.** (None yet — run the scout to fill.)
 
 ## Conventions for items
 

--- a/research/README.md
+++ b/research/README.md
@@ -33,18 +33,24 @@ Method, Spyx modules used, How to run, Results table, Findings, Reproducibility.
 
 Research here runs on a loop with a human gate:
 
+- **[`/research-scout`](../.claude/skills/research-scout.md)** — surveys current
+  papers and proposes backlog **candidates**, each classified `replication` /
+  `extension` / `novelty` against the taxonomy above. You triage candidates to `ready`.
 - **[BACKLOG.md](BACKLOG.md)** — the queue of falsifiable claims to study. Current
   focus track: **quantization & efficient architectures.**
+- **[`/research-study`](../.claude/skills/research-study.md)** — the runner: pulls the
+  top backlog item, builds and adversarially verifies one study, opens a PR + ledger
+  row, and **stops at the gate**. Two modes — **scheduled web** (smoke/CPU only) and
+  **local loop** on the AMD GPU (bounded small-scale *real* runs). Never edits core,
+  never promotes, never merges.
 - **[FINDINGS.md](FINDINGS.md)** — the ledger: every study's honest verdict and its
   promotion status. Your review surface.
 - **[PROMOTION.md](PROMOTION.md)** — the gate: criteria for `research →
   spyx.experimental → core`. Every rung up is a human decision.
-- **[`/research-study`](../.claude/skills/research-study.md)** — the unattended runner
-  (a scheduled Claude Code web task): pulls the top backlog item, builds and
-  adversarially verifies one study, opens a PR + ledger row, and **stops at the gate**
-  — never edits core, never runs GPU/full budgets, never promotes.
 - **[`/promote-finding`](../.claude/skills/promote-finding.md)** — you invoke this when
   you decide to graduate a finding; it runs the checklist and stages the promotion PR.
+
+The loop: **scout → triage → study (web breadth / local-GPU depth) → review → promote.**
 
 Honest negatives and nulls are first-class: they stay in `research/`, indexed in the
 ledger, and are never deleted or reshaped.


### PR DESCRIPTION
Follow-up to #64, adding the two dimensions raised in review: **literature-driven scouting** and a **local-loop GPU runner mode**.

## Literature scout (`/research-scout`)
Actively researches current papers in the focus track and proposes **backlog candidates**, each classified against the repo taxonomy — **replication** (reproduce a paper's claim in Spyx), **extension** (push a method somewhere new), **novelty** (a gap Spyx is suited to fill). Uses WebSearch/WebFetch, cites real sources, proposes only — you triage candidates to `ready`. Keeps the queue from running dry. This is the "actively research against current papers, identify replication/extensions/novelties" front-end.

## Two runner modes (`/research-study`)
- **Scheduled web** — no GPU, smoke/CPU only, flags GPU/full runs for a human.
- **Local loop** (your AMD gfx1151 box, `~/.venvs/jax-rocm-0.9.2`) — MAY run **bounded small-scale real experiments** (≤~15 min, reduced sweep), so findings land *real, not pending*. Bigger runs stay human-gated. Deps install `--no-deps` into the pinned ROCm venv.

The gate is identical in both modes: never edits core, never promotes, never merges — PR + ledger row for your review.

## Also
- `BACKLOG.md`: a **Candidates** section (scout output, pre-triage) + bucket tags.
- `research/README.md`: documents the full loop — **scout → triage → study (web breadth / local-GPU depth) → review → promote.**

Docs + skills only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)