### PR TITLE
feat(nn): AssociativeLIF — parallel LIF at parity with snnTorch StateLeaky

### DIFF
--- a/src/spyx/experimental/__init__.py
+++ b/src/spyx/experimental/__init__.py
@@ -12,6 +12,10 @@ Contents:
 - :class:`~spyx.experimental.PSU_LIF` — reset-free parallel LIF (parallel
   associative-scan spiking neuron). *Physically defined in* ``spyx.nn`` *and
   surfaced here as its supported, experimental entry point.*
+- :class:`~spyx.experimental.AssociativeLIF` — thin alias of ``PSU_LIF`` at
+  exact numeric parity with snnTorch v1.0.0 ``snntorch.StateLeaky`` (after a
+  ``beta`` reparameterisation). It does **not** replicate snnTorch's
+  ``AssociativeLeaky``, which is a different matrix-state associative-memory SSM.
 - :class:`~spyx.experimental.ResonateFire` — complex resonate-and-fire oscillatory
   neuron. *Physically defined in* ``spyx.phasor``.
 - :mod:`spyx.experimental.raven` — Routing Slot Memories (``RavenRSM``) and the
@@ -41,7 +45,7 @@ Related research studies live under ``research/new/`` in the repository.
 
 # Re-exported from the stable modules where they are physically defined; grouped
 # here so the experimental surface is discoverable in one place.
-from ..nn import PSU_LIF
+from ..nn import PSU_LIF, AssociativeLIF
 from ..phasor import ResonateFire
 from . import compress, evolve, hybrid, matfree, onnx, raven, stochastic, zoo
 from .compress import pack_spikes, packed_spike_dense, unpack_spikes
@@ -72,6 +76,7 @@ __all__ = [
     "stochastic",
     "zoo",
     "PSU_LIF",
+    "AssociativeLIF",
     "ResonateFire",
     "RavenRSM",
     "SpikingSlotMemory",

--- a/src/spyx/nn.py
+++ b/src/spyx/nn.py
@@ -338,6 +338,70 @@ class PSU_LIF(nnx.Module):
         return jnp.zeros((batch_size,) + self.hidden_shape)
 
 
+class AssociativeLIF(PSU_LIF):
+    r"""Reset-free parallel LIF, named for snnTorch cross-referencing.
+
+    .. note::
+       **Experimental.** Supported entry point:
+       :class:`spyx.experimental.AssociativeLIF`. Thin alias of
+       :class:`PSU_LIF` — same ``__init__`` signature, same
+       ``(x, V) -> (spikes, V)`` step contract, same :meth:`parallel`
+       associative scan. It exists purely for discoverability by users
+       coming from snnTorch.
+
+    **Parity target.** This is at exact numeric parity (float32, verified to
+    ``< 1e-6`` max-abs membrane difference; spike trains identical) with
+    snnTorch v1.0.0 ``snntorch.StateLeaky`` — the reset-free scalar parallel
+    leaky integrator — *after a single beta reparameterisation* (see below).
+
+    .. warning::
+       Despite the name, this does **not** replicate snnTorch's
+       ``snntorch.AssociativeLeaky``. That neuron is *not* a leaky
+       integrate-and-fire unit at all: it is a matrix-valued associative-memory
+       SSM (linear-attention / fast-weight style) that forms key/value outer
+       products, decays a matrix state in log-space, and reads out
+       ``S_t @ Q_t`` with input-dependent per-column decay. A scalar LIF cannot
+       express it; that behaviour would be a separate linear-attention module.
+
+    **Decay reparameterisation.** ``PSU_LIF`` uses ``beta`` directly as the
+    per-step decay, :math:`V_t = \beta V_{t-1} + x_t`. ``StateLeaky`` instead
+    reads ``beta`` as a continuous time constant :math:`\tau = 1/(1-\beta)` and
+    builds a kernel :math:`h[t] = e^{-t/\tau}`, so its *effective* per-step
+    decay is :math:`e^{-1/\tau} = e^{-(1-\beta_\text{snn})}`. The same symbol
+    means different things: ``beta_snn = 0.9`` gives an effective decay of
+    ``0.9048``, not ``0.9``. Use :meth:`beta_from_snntorch` to convert a
+    snnTorch ``beta`` into the spyx ``beta`` that reproduces StateLeaky exactly,
+    and :meth:`snntorch_beta_from_beta` for the inverse.
+    """
+
+    @staticmethod
+    def beta_from_snntorch(beta_snn):
+        r"""Convert a snnTorch ``StateLeaky`` beta into the spyx ``beta``.
+
+        ``StateLeaky`` treats ``beta`` as a time constant
+        :math:`\tau = 1/(1 - \beta_\text{snn})` and uses an effective per-step
+        decay :math:`e^{-1/\tau} = e^{-(1 - \beta_\text{snn})}`. Passing the
+        returned value as this class's ``beta`` makes the membrane trace (and
+        therefore the spikes) match ``StateLeaky`` exactly.
+
+        :beta_snn: snnTorch ``StateLeaky`` beta in ``(0, 1)``.
+        :return: the equivalent spyx per-step decay ``beta``.
+        """
+        return jnp.exp(-(1.0 - jnp.asarray(beta_snn)))
+
+    @staticmethod
+    def snntorch_beta_from_beta(beta):
+        r"""Inverse of :meth:`beta_from_snntorch`.
+
+        Recovers the snnTorch ``StateLeaky`` beta from a spyx per-step decay
+        via :math:`\beta_\text{snn} = 1 + \ln \beta`.
+
+        :beta: spyx per-step decay ``beta`` in ``(0, 1]``.
+        :return: the equivalent snnTorch ``StateLeaky`` beta.
+        """
+        return 1.0 + jnp.log(jnp.asarray(beta))
+
+
 class CuBaLIF(nnx.Module):
     def __init__(
         self,

--- a/tests/test_stateleaky_parity.py
+++ b/tests/test_stateleaky_parity.py
@@ -1,0 +1,164 @@
+"""Numeric-parity tests for :class:`spyx.experimental.AssociativeLIF`.
+
+Two independent layers of assurance:
+
+A. **Analytic** (always runs, no external dependency): the associative-scan
+   membrane and a scan of ``__call__`` both match the closed-form geometric
+   recurrence ``mem_t = sum_{s<=t} beta**(t-s) * x_s``, and spikes follow the
+   Heaviside threshold.
+B. **Cross-check vs snnTorch** (skipped if torch/snntorch are missing): the
+   spyx membrane and spikes match ``snntorch.StateLeaky`` once ``beta`` is
+   reparameterised via :meth:`AssociativeLIF.beta_from_snntorch`.  A regression
+   assertion documents that the *naive* (unconverted) mapping does **not**
+   match, guarding against anyone "fixing" the reparameterisation wrongly.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from spyx import nn
+from spyx.experimental import AssociativeLIF
+
+
+def _reference_membrane(x, beta):
+    """Closed-form reset-free membrane via an explicit python recurrence."""
+    T = x.shape[0]
+    V = jnp.zeros(x.shape[1:])
+    out = []
+    for t in range(T):
+        V = beta * V + x[t]
+        out.append(V)
+    return jnp.stack(out)
+
+
+def test_is_psu_lif_subclass_and_helpers_roundtrip():
+    """AssociativeLIF is a PSU_LIF subclass; beta helpers invert each other."""
+    from spyx.nn import PSU_LIF
+
+    assert issubclass(AssociativeLIF, PSU_LIF)
+
+    for b in (0.5, 0.8, 0.9, 0.95):
+        beta_spyx = AssociativeLIF.beta_from_snntorch(b)
+        back = AssociativeLIF.snntorch_beta_from_beta(beta_spyx)
+        assert jnp.allclose(back, b, atol=1e-6)
+        # StateLeaky's effective per-step decay is exp(-(1-beta_snn)).
+        assert jnp.allclose(beta_spyx, jnp.exp(-(1.0 - b)), atol=1e-7)
+
+
+@pytest.mark.parametrize("beta", [0.5, 0.8, 0.9, 0.95])
+@pytest.mark.parametrize("T", [8, 64])
+def test_analytic_membrane_and_spikes(beta, T):
+    """parallel + scan(__call__) match the geometric recurrence and spikes."""
+    B, C = 3, 6
+    model = AssociativeLIF((C,), beta=beta, threshold=1.0, rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.key(T), (T, B, C))
+
+    ref_mem = _reference_membrane(x, jnp.clip(model.beta[...], 0, 1))
+
+    # Membrane recovered from the associative scan itself.
+    A = jnp.broadcast_to(jnp.clip(model.beta[...], 0, 1), x.shape)
+    _, par_mem = jax.lax.associative_scan(nn._leaky_associative_op, (A, x), axis=0)
+    assert jnp.allclose(par_mem, ref_mem, atol=1e-5)
+
+    # Spikes are a strict Heaviside on the membrane.
+    par_spk = model.parallel(x)
+    assert jnp.allclose(par_spk, (ref_mem > model.threshold).astype(x.dtype))
+
+    # Sequential scan of __call__ matches parallel exactly.
+    seq_spk, _ = nn.run(model, x)
+    assert jnp.allclose(seq_spk, par_spk, atol=1e-6)
+
+
+def test_parallel_equals_sequential_per_unit_beta():
+    """Learnable per-unit beta: parallel == sequential."""
+    model = AssociativeLIF((12,), rngs=nnx.Rngs(1))
+    x = jax.random.normal(jax.random.key(0), (20, 4, 12))
+    par = model.parallel(x)
+    seq, _ = nn.run(model, x)
+    assert jnp.allclose(par, seq, atol=1e-6)
+
+
+@pytest.mark.parametrize("beta_snn", [0.5, 0.8, 0.9, 0.95])
+@pytest.mark.parametrize("T", [8, 64])
+@pytest.mark.parametrize("scalar_beta", [True, False])
+def test_snntorch_stateleaky_parity(beta_snn, T, scalar_beta):
+    """spyx AssociativeLIF == snnTorch StateLeaky for a matched, converted beta."""
+    torch = pytest.importorskip("torch")
+    snntorch = pytest.importorskip("snntorch")
+
+    B, C = 3, 5
+    rng = np.random.default_rng(T)
+    x = rng.standard_normal((T, B, C)).astype(np.float32)
+
+    sl = snntorch.StateLeaky(
+        beta=beta_snn,
+        channels=C,
+        output=True,
+        surrogate_disable=True,
+        kernel_truncation_steps=None,
+    )
+    sl_spk, sl_mem = sl(torch.tensor(x))
+    sl_mem = sl_mem.detach().numpy()
+    sl_spk = sl_spk.detach().numpy()
+
+    beta_spyx = float(AssociativeLIF.beta_from_snntorch(beta_snn))
+    model = AssociativeLIF((C,), beta=beta_spyx, threshold=1.0, rngs=nnx.Rngs(0))
+    if not scalar_beta:
+        # Exercise the per-unit (broadcast) beta path with the same value on
+        # every channel; PSU_LIF's __init__ only takes a scalar fixed beta.
+        model.beta = nnx.Param(jnp.full((C,), beta_spyx, dtype=jnp.float32))
+
+    xa = jnp.asarray(x)
+    A = jnp.broadcast_to(jnp.clip(model.beta[...], 0, 1), xa.shape)
+    _, mem = jax.lax.associative_scan(nn._leaky_associative_op, (A, xa), axis=0)
+    spk = model.parallel(xa)
+
+    mem_diff = float(np.max(np.abs(np.asarray(mem) - sl_mem)))
+    assert mem_diff < 1e-5, f"membrane max-abs-diff {mem_diff}"
+    assert np.array_equal(np.asarray(spk), sl_spk)
+
+
+def test_snntorch_naive_mapping_regression():
+    """Regression: using beta == beta_snn (no reparam) does NOT match StateLeaky.
+
+    Guards against anyone "simplifying" the reparameterisation away.
+    """
+    torch = pytest.importorskip("torch")
+    snntorch = pytest.importorskip("snntorch")
+
+    B, C, T, beta_snn = 3, 5, 32, 0.9
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((T, B, C)).astype(np.float32)
+
+    sl = snntorch.StateLeaky(
+        beta=beta_snn,
+        channels=C,
+        output=True,
+        surrogate_disable=True,
+        kernel_truncation_steps=None,
+    )
+    _, sl_mem = sl(torch.tensor(x))
+    sl_mem = sl_mem.detach().numpy()
+
+    # Naive (wrong) mapping: pass beta_snn straight through.
+    naive = AssociativeLIF((C,), beta=beta_snn, threshold=1.0, rngs=nnx.Rngs(0))
+    xa = jnp.asarray(x)
+    A = jnp.broadcast_to(jnp.clip(naive.beta[...], 0, 1), xa.shape)
+    _, mem = jax.lax.associative_scan(nn._leaky_associative_op, (A, xa), axis=0)
+    naive_diff = float(np.max(np.abs(np.asarray(mem) - sl_mem)))
+    assert naive_diff > 1e-3, (
+        f"naive mapping unexpectedly matched (diff {naive_diff}); "
+        "the beta reparameterisation must be preserved"
+    )
+
+
+if __name__ == "__main__":
+    test_is_psu_lif_subclass_and_helpers_roundtrip()
+    for b in (0.5, 0.9):
+        for t in (8, 64):
+            test_analytic_membrane_and_spikes(b, t)
+    test_parallel_equals_sequential_per_unit_beta()
+    print("Analytic tests passed!")


### PR DESCRIPTION
The field survey retired Spyx's "only associative-scan spiking neuron" claim (snnTorch v1.0.0 ships parallel neurons). This establishes **provable parity** and gives users a familiar name.

**Key correction from the parity investigation:** snnTorch's `AssociativeLeaky` is *not* a LIF — it's a matrix associative-memory SSM (linear-attention/fast-weight). The actual parallel leaky integrator in snnTorch is **`StateLeaky`**, and Spyx's `PSU_LIF` is **numerically identical to it** (verified to 3.6e-7) up to a `beta` reparameterisation: StateLeaky treats `beta` as a continuous time constant `tau=1/(1-beta)`, so `beta_spyx = exp(-(1-beta_snn))`.

## Change
- `AssociativeLIF` (thin `PSU_LIF` subclass) exported from `spyx.experimental`, with `beta_from_snntorch` / `snntorch_beta_from_beta` conversion helpers, and a docstring documenting parity with snnTorch `StateLeaky` + a warning that `AssociativeLeaky` is a different SSM (don't confuse them).
- `tests/test_stateleaky_parity.py`: analytic geometric-recurrence parity (always runs) **+ a real `snntorch` cross-check** (snntorch 1.0.0 + torch 2.12 are installed) — asserts membrane traces match to 1e-5 and spike trains exactly, across beta ∈ {.5,.8,.9,.95}, scalar & per-channel, plus a regression guard that the *wrong* (identity) beta mapping does NOT match.

**27 passed; ruff + ty clean.** Built by an ultracode workflow (the investigation caught the AssociativeLeaky-vs-StateLeaky mixup); reviewed + validated locally before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)