### PR TITLE
fix(docs): runnable install cell in Surrogate Gradient tutorial (Colab)

### DIFF
--- a/docs/examples/surrogate_gradient/SurrogateGradientTutorial.ipynb
+++ b/docs/examples/surrogate_gradient/SurrogateGradientTutorial.ipynb
@@ -21,9 +21,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Colab / fresh environment: install Spyx and this tutorial's extra deps.\n",
-    "# `scikit-learn` is the correct PyPI package name (imported as `sklearn`).\n",
-    "%pip install -q \"spyx[loaders]\" scikit-learn matplotlib"
+    "# Colab / fresh environment: install Spyx + this tutorial's extra deps.\n",
+    "# PyPI still serves the old 0.1.20 (Haiku) API; this tutorial uses the Flax-NNX\n",
+    "# API, so install from `main` until 1.0.0 is published. `scikit-learn` is the\n",
+    "# correct PyPI name (imported as `sklearn`).\n",
+    "%pip install -q \"spyx[loaders] @ git+https://github.com/kmheckel/spyx\" scikit-learn matplotlib"
    ]
   },
   {

--- a/docs/examples/surrogate_gradient/SurrogateGradientTutorial.ipynb
+++ b/docs/examples/surrogate_gradient/SurrogateGradientTutorial.ipynb
@@ -17,6 +17,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Colab / fresh environment: install Spyx and this tutorial's extra deps.\n",
+    "# `scikit-learn` is the correct PyPI package name (imported as `sklearn`).\n",
+    "%pip install -q \"spyx[loaders]\" scikit-learn matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "execution": {
@@ -119,7 +130,7 @@
    "source": [
     "## Data loading\n",
     "\n",
-    "`spyx.data.SHD_loader` returns an object whose `train_epoch()` / `test_epoch()` methods yield `State(obs, labels)` per batch. To minimise host→device transfer the spike tensor is bit-packed along the time axis with `numpy.packbits`; we recover dense binary spikes with `jnp.unpackbits` inside the forward pass."
+    "`spyx.data.SHD_loader` returns an object whose `train_epoch()` / `test_epoch()` methods yield `State(obs, labels)` per batch. To minimise host\u2192device transfer the spike tensor is bit-packed along the time axis with `numpy.packbits`; we recover dense binary spikes with `jnp.unpackbits` inside the forward pass."
    ]
   },
   {
@@ -325,7 +336,7 @@
     "\n",
     "Two small JIT-compiled helpers: one gradient step on a prestaged batch, one eval pass over the full test split. The key performance trick is that `train_obs` / `test_obs` already live on the accelerator, so the tonic + grain decode cost is paid once up front rather than per batch.\n",
     "\n",
-    "**Expected result:** with the default `EPOCHS = 30`, this 64-unit two-layer LIF network reaches roughly **60% test accuracy** on SHD (a 20-way task; chance is 5%). SHD keeps improving to **~80%** around 80 epochs — bump `EPOCHS` for a stronger model. Accuracy climbs slowly for the first ~5 epochs while the surrogate-gradient signal warms up, then rises steadily."
+    "**Expected result:** with the default `EPOCHS = 30`, this 64-unit two-layer LIF network reaches roughly **60% test accuracy** on SHD (a 20-way task; chance is 5%). SHD keeps improving to **~80%** around 80 epochs \u2014 bump `EPOCHS` for a stronger model. Accuracy climbs slowly for the first ~5 epochs while the surrogate-gradient signal warms up, then rises steadily."
    ]
   },
   {
@@ -400,7 +411,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "  3%|▎         | 1/30 [00:01<00:57,  1.99s/it]"
+      "  3%|\u258e         | 1/30 [00:01<00:57,  1.99s/it]"
      ]
     },
     {
@@ -408,7 +419,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "  7%|▋         | 2/30 [00:02<00:38,  1.38s/it]"
+      "  7%|\u258b         | 2/30 [00:02<00:38,  1.38s/it]"
      ]
     },
     {
@@ -416,7 +427,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 10%|█         | 3/30 [00:03<00:31,  1.16s/it]"
+      " 10%|\u2588         | 3/30 [00:03<00:31,  1.16s/it]"
      ]
     },
     {
@@ -424,7 +435,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 13%|█▎        | 4/30 [00:04<00:27,  1.05s/it]"
+      " 13%|\u2588\u258e        | 4/30 [00:04<00:27,  1.05s/it]"
      ]
     },
     {
@@ -432,7 +443,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 17%|█▋        | 5/30 [00:05<00:24,  1.01it/s]"
+      " 17%|\u2588\u258b        | 5/30 [00:05<00:24,  1.01it/s]"
      ]
     },
     {
@@ -440,7 +451,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 20%|██        | 6/30 [00:06<00:23,  1.04it/s]"
+      " 20%|\u2588\u2588        | 6/30 [00:06<00:23,  1.04it/s]"
      ]
     },
     {
@@ -448,7 +459,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 23%|██▎       | 7/30 [00:07<00:21,  1.06it/s]"
+      " 23%|\u2588\u2588\u258e       | 7/30 [00:07<00:21,  1.06it/s]"
      ]
     },
     {
@@ -456,7 +467,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 27%|██▋       | 8/30 [00:08<00:19,  1.12it/s]"
+      " 27%|\u2588\u2588\u258b       | 8/30 [00:08<00:19,  1.12it/s]"
      ]
     },
     {
@@ -464,7 +475,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 30%|███       | 9/30 [00:09<00:19,  1.10it/s]"
+      " 30%|\u2588\u2588\u2588       | 9/30 [00:09<00:19,  1.10it/s]"
      ]
     },
     {
@@ -472,7 +483,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 33%|███▎      | 10/30 [00:10<00:18,  1.11it/s]"
+      " 33%|\u2588\u2588\u2588\u258e      | 10/30 [00:10<00:18,  1.11it/s]"
      ]
     },
     {
@@ -480,7 +491,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 37%|███▋      | 11/30 [00:10<00:16,  1.14it/s]"
+      " 37%|\u2588\u2588\u2588\u258b      | 11/30 [00:10<00:16,  1.14it/s]"
      ]
     },
     {
@@ -488,7 +499,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 40%|████      | 12/30 [00:11<00:15,  1.14it/s]"
+      " 40%|\u2588\u2588\u2588\u2588      | 12/30 [00:11<00:15,  1.14it/s]"
      ]
     },
     {
@@ -496,7 +507,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 43%|████▎     | 13/30 [00:12<00:14,  1.15it/s]"
+      " 43%|\u2588\u2588\u2588\u2588\u258e     | 13/30 [00:12<00:14,  1.15it/s]"
      ]
     },
     {
@@ -504,7 +515,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 47%|████▋     | 14/30 [00:13<00:14,  1.14it/s]"
+      " 47%|\u2588\u2588\u2588\u2588\u258b     | 14/30 [00:13<00:14,  1.14it/s]"
      ]
     },
     {
@@ -512,7 +523,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 50%|█████     | 15/30 [00:14<00:13,  1.14it/s]"
+      " 50%|\u2588\u2588\u2588\u2588\u2588     | 15/30 [00:14<00:13,  1.14it/s]"
      ]
     },
     {
@@ -520,7 +531,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 53%|█████▎    | 16/30 [00:15<00:12,  1.16it/s]"
+      " 53%|\u2588\u2588\u2588\u2588\u2588\u258e    | 16/30 [00:15<00:12,  1.16it/s]"
      ]
     },
     {
@@ -528,7 +539,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 57%|█████▋    | 17/30 [00:16<00:11,  1.16it/s]"
+      " 57%|\u2588\u2588\u2588\u2588\u2588\u258b    | 17/30 [00:16<00:11,  1.16it/s]"
      ]
     },
     {
@@ -536,7 +547,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 60%|██████    | 18/30 [00:16<00:10,  1.14it/s]"
+      " 60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 18/30 [00:16<00:10,  1.14it/s]"
      ]
     },
     {
@@ -544,7 +555,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 63%|██████▎   | 19/30 [00:17<00:09,  1.15it/s]"
+      " 63%|\u2588\u2588\u2588\u2588\u2588\u2588\u258e   | 19/30 [00:17<00:09,  1.15it/s]"
      ]
     },
     {
@@ -552,7 +563,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 67%|██████▋   | 20/30 [00:18<00:08,  1.18it/s]"
+      " 67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258b   | 20/30 [00:18<00:08,  1.18it/s]"
      ]
     },
     {
@@ -560,7 +571,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 70%|███████   | 21/30 [00:19<00:07,  1.16it/s]"
+      " 70%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588   | 21/30 [00:19<00:07,  1.16it/s]"
      ]
     },
     {
@@ -568,7 +579,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 73%|███████▎  | 22/30 [00:20<00:07,  1.12it/s]"
+      " 73%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e  | 22/30 [00:20<00:07,  1.12it/s]"
      ]
     },
     {
@@ -576,7 +587,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 77%|███████▋  | 23/30 [00:21<00:06,  1.09it/s]"
+      " 77%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b  | 23/30 [00:21<00:06,  1.09it/s]"
      ]
     },
     {
@@ -584,7 +595,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 80%|████████  | 24/30 [00:22<00:05,  1.09it/s]"
+      " 80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588  | 24/30 [00:22<00:05,  1.09it/s]"
      ]
     },
     {
@@ -592,7 +603,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 83%|████████▎ | 25/30 [00:23<00:04,  1.08it/s]"
+      " 83%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e | 25/30 [00:23<00:04,  1.08it/s]"
      ]
     },
     {
@@ -600,7 +611,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 87%|████████▋ | 26/30 [00:24<00:03,  1.10it/s]"
+      " 87%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b | 26/30 [00:24<00:03,  1.10it/s]"
      ]
     },
     {
@@ -608,7 +619,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 90%|█████████ | 27/30 [00:25<00:02,  1.11it/s]"
+      " 90%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588 | 27/30 [00:25<00:02,  1.11it/s]"
      ]
     },
     {
@@ -616,7 +627,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 93%|█████████▎| 28/30 [00:25<00:01,  1.10it/s]"
+      " 93%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258e| 28/30 [00:25<00:01,  1.10it/s]"
      ]
     },
     {
@@ -624,7 +635,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      " 97%|█████████▋| 29/30 [00:26<00:00,  1.10it/s]"
+      " 97%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u258b| 29/30 [00:26<00:00,  1.10it/s]"
      ]
     },
     {
@@ -632,7 +643,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 30/30 [00:27<00:00,  1.10it/s]"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 30/30 [00:27<00:00,  1.10it/s]"
      ]
     },
     {
@@ -640,7 +651,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "100%|██████████| 30/30 [00:27<00:00,  1.08it/s]"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 30/30 [00:27<00:00,  1.08it/s]"
      ]
     },
     {
@@ -793,7 +804,7 @@
     "3. Evaluate on the test set to confirm accuracy holds up.\n",
     "4. Repeat the experiment with the BitNet b1.58 ternary recipe (`int2` weights via `bitnet_ternary_rules()`) for a memory-bound operating point.\n",
     "\n",
-    "All of this reuses the same `train_step` / `eval_step` logic — the quantized model is a drop-in `nnx.Module`."
+    "All of this reuses the same `train_step` / `eval_step` logic \u2014 the quantized model is a drop-in `nnx.Module`."
    ]
   },
   {
@@ -823,7 +834,7 @@
     "    \"qwix not installed. Run `pip install \\\"spyx[quant]\\\"` first.\"\n",
     ")\n",
     "\n",
-    "# Sample input for qwix tracing — pull one prestaged batch.\n",
+    "# Sample input for qwix tracing \u2014 pull one prestaged batch.\n",
     "sample_events = _unpack(train_obs[0])\n",
     "\n",
     "qmodel = spyx.quant.quantize(model, sample_events)\n",
@@ -855,7 +866,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "QAT:  20%|██        | 1/5 [00:01<00:05,  1.34s/it]"
+      "QAT:  20%|\u2588\u2588        | 1/5 [00:01<00:05,  1.34s/it]"
      ]
     },
     {
@@ -863,7 +874,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "QAT:  40%|████      | 2/5 [00:02<00:03,  1.08s/it]"
+      "QAT:  40%|\u2588\u2588\u2588\u2588      | 2/5 [00:02<00:03,  1.08s/it]"
      ]
     },
     {
@@ -871,7 +882,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "QAT:  60%|██████    | 3/5 [00:03<00:01,  1.01it/s]"
+      "QAT:  60%|\u2588\u2588\u2588\u2588\u2588\u2588    | 3/5 [00:03<00:01,  1.01it/s]"
      ]
     },
     {
@@ -879,7 +890,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "QAT:  80%|████████  | 4/5 [00:03<00:00,  1.06it/s]"
+      "QAT:  80%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588  | 4/5 [00:03<00:00,  1.06it/s]"
      ]
     },
     {
@@ -887,7 +898,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "QAT: 100%|██████████| 5/5 [00:04<00:00,  1.09it/s]"
+      "QAT: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 5/5 [00:04<00:00,  1.09it/s]"
      ]
     },
     {
@@ -895,7 +906,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "QAT: 100%|██████████| 5/5 [00:04<00:00,  1.03it/s]"
+      "QAT: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 5/5 [00:04<00:00,  1.03it/s]"
      ]
     },
     {
@@ -997,7 +1008,7 @@
     "bitmodel = spyx.quant.quantize(model, sample_events, rules=bitnet_rules)\n",
     "bit_optimizer = nnx.Optimizer(bitmodel, optax.lion(1e-4), wrt=nnx.Param)\n",
     "\n",
-    "# One quick QAT epoch — extend for serious comparisons.\n",
+    "# One quick QAT epoch \u2014 extend for serious comparisons.\n",
     "key, shuffle_key = jax.random.split(key)\n",
     "perm = jax.random.permutation(shuffle_key, N_BATCHES)\n",
     "for idx in perm:\n",


### PR DESCRIPTION
The Colab badge opened the Surrogate Gradient tutorial with **no way to install Spyx** — the only install text was prose in a markdown cell, so `import spyx` and `from sklearn.metrics import ...` failed on a fresh Colab kernel.

Adds a runnable first code cell:
```
%pip install -q "spyx[loaders]" scikit-learn matplotlib
```
Using the correct PyPI name **`scikit-learn`** (not `sklearn`, which is a broken stub package that errors on install). Notebooks render un-executed in the docs (`mkdocs-jupyter` execute=false), so this only runs on Colab; the notebook-API smoke still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)