### PR TITLE
docs: tutorial installs spyx from PyPI now that 1.0.0 is published

### DIFF
--- a/docs/examples/surrogate_gradient/SurrogateGradientTutorial.ipynb
+++ b/docs/examples/surrogate_gradient/SurrogateGradientTutorial.ipynb
@@ -22,10 +22,8 @@
    "outputs": [],
    "source": [
     "# Colab / fresh environment: install Spyx + this tutorial's extra deps.\n",
-    "# PyPI still serves the old 0.1.20 (Haiku) API; this tutorial uses the Flax-NNX\n",
-    "# API, so install from `main` until 1.0.0 is published. `scikit-learn` is the\n",
-    "# correct PyPI name (imported as `sklearn`).\n",
-    "%pip install -q \"spyx[loaders] @ git+https://github.com/kmheckel/spyx\" scikit-learn matplotlib"
+    "# `scikit-learn` is the correct PyPI name (imported as `sklearn`).\n",
+    "%pip install -q \"spyx[loaders]\" scikit-learn matplotlib"
    ]
   },
   {


### PR DESCRIPTION
Reverts the temporary `git+main` install (added while PyPI was stuck at 0.1.20) back to `%pip install -q "spyx[loaders]" scikit-learn matplotlib` — spyx 1.0.0 (Flax-NNX API) is now on PyPI, so the Colab badge works straight from the release. Notebook-API smoke passes.