### PR TITLE
feat(experimental): SigmaDelta — graded sigma-delta neuron (efficient inference on redundant input)

### DIFF
--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -34,6 +34,7 @@ FP4×SNN gap and its neighbours).
 | [parallel_spiking_neurons](new/parallel_spiking_neurons/) | Reset-free / R&F neurons parallelize the time loop, no accuracy loss | ✅ | core | `spyx.nn.PSU_LIF`, `spyx.phasor.ResonateFire` |
 | [reset_preserving_parallel_lif](new/reset_preserving_parallel_lif/) | Parallelize a hard-reset LIF while keeping the exact reset (FPT) | ✅ | experimental | `ParallelResetLIF`: exact + ~1.7–2.4× over sequential on GPU |
 | [rf_ssm](new/rf_ssm/) | S5-RF (HiPPO init + decoupled reset) beats plain R&F on long-range | ➖ | experimental | `RFSSM`: scan-exact + ~4×, but **no accuracy win** over the simpler neurons here |
+| [sigma_delta_neuron](new/sigma_delta_neuron/) | Graded sigma-delta neuron transmits fewer events at matched accuracy on redundant input | ✅ | experimental | `spyx.experimental.SigmaDelta`: **3.84× fewer events** vs LIF at matched acc (redundancy-dependent; event-driven-HW win) |
 | [pallas_neurons](new/pallas_neurons/) | A fused Pallas neuron kernel is worth building (#24) | ❌ | new | matmul-bound; `associative_scan` already gives 2–21× portably |
 
 ### Training methods, SSMs & memory

--- a/research/new/sigma_delta_neuron/README.md
+++ b/research/new/sigma_delta_neuron/README.md
@@ -1,0 +1,80 @@
+# Sigma-delta / graded-spike neuron: fewer events at matched accuracy
+
+## Title
+
+`spyx.experimental.SigmaDelta` — a graded neuron that transmits only the quantized
+*change* in its membrane — vs a rate-coded `spyx.nn.LIF` on temporally-redundant input.
+
+## Paper & arXiv/DOI
+
+- **Title:** novel Spyx neuron; the change-transmission mechanism is prior art.
+- **Prior art:** O'Connor & Welling, *Sigma-Delta Quantized Networks*, ICLR 2017
+  ([arXiv:1611.02024](https://arxiv.org/abs/1611.02024)); Shrestha et al., Loihi-2
+  resonate-and-fire + sigma-delta, ICASSP 2024 ([arXiv:2310.03251](https://arxiv.org/abs/2310.03251)).
+  Reference impl is Intel `lava-dl` (`slayer.neuron.sigma_delta`, PyTorch); **no clean
+  JAX/Flax graded neuron existed** — this is the first, with an `associative_scan`
+  `.parallel` path.
+- **Bucket:** new
+
+## Claim under test
+
+On **temporally-redundant** input (a signal that holds a value), a sigma-delta graded
+neuron reaches the **same accuracy as a rate-coded LIF while transmitting far fewer
+events** — because it emits only the quantized change of its membrane, which is ~0 when
+the input is stable. Event rate (fraction of non-zero events per step) is the
+device-agnostic energy proxy: each transmitted event is one synaptic op / packet,
+graded or binary.
+
+## Method
+
+`Linear → {LIF | SigmaDelta} → Linear → LI`, identical architecture and budget, on a
+synthetic **step-and-hold** task: each class's channel band jumps to a constant level
+early and holds it to the end (genuine temporal redundancy). Adam, `integral_crossentropy`.
+Report per neuron: test accuracy and mean non-zero-event rate (the hidden neuron's
+output scanned over the pre-activation). Also the `SigmaDelta.parallel` associative-scan
+throughput via `spyx.bench`. Self-contained; no dataset.
+
+## Spyx modules used
+
+- [`spyx.experimental.SigmaDelta`](../../../src/spyx/experimental/sigma_delta.py) / `graded_quant`
+- [`spyx.nn.LIF`](../../../src/spyx/nn.py) / `Sequential` / `run`, [`spyx.bench`](../../../src/spyx/bench.py), [`spyx.fn`](../../../src/spyx/fn.py)
+
+## How to run
+
+```bash
+SPYX_SMOKE=1 uv run python research/new/sigma_delta_neuron/sigma_delta_bench.py   # tiny, CPU
+uv run python research/new/sigma_delta_neuron/sigma_delta_bench.py                # full
+```
+
+Writes `sigma_delta_results.json`.
+
+## Findings
+
+**Full run on the Radeon 8060S** (C=32, H=64, 5-class step-and-hold, T=80, 2 seeds):
+
+| Neuron | Test acc | Event rate | Note |
+| --- | --- | --- | --- |
+| LIF (rate-coded) | 99.4% | 11.0% | fires through the whole hold |
+| **SigmaDelta** | **99.8%** | **2.9%** | fires at the step, then silent |
+
+**Sigma-delta transmits 3.84× fewer events at matched (slightly better) accuracy** on
+genuinely redundant input — the efficiency mechanism works, and the graded neuron drops
+into `spyx.nn.Sequential`/`run` and parallelises with an `associative_scan` like the
+binary neurons.
+
+**Honest caveats.** (1) The win is **redundancy-dependent** — on a *continuously-varying*
+input (a half-sine, tried first) sigma-delta does **not** win, because the membrane keeps
+changing so it keeps emitting. The benefit requires genuinely stable stretches. (2) A
+graded event carries more bits than a binary spike, so "3.84× fewer events" is the
+event-count story, not a full energy accounting (see `../honest_energy_accounting/`).
+(3) On a dense GPU neither sparsity is exploited — the win is realised on event-driven /
+neuromorphic hardware. (4) This is the *feedforward* delta form, which drifts by
+`O(sqrt(T)·step)` over long sequences (a closed-loop drift-free variant is sequential).
+
+## Reproducibility
+
+- **Seeds:** `nnx.Rngs(seed)` init; NumPy `default_rng(seed)` for the synthetic task. `SEEDS=[0]` (smoke) / `[0,1]` (full).
+- **JAX / hardware:** full run on Radeon 8060S / gfx1151 (ROCm); device in the JSON. Runs on CPU too (small).
+- **Correctness:** `tests/test_sigma_delta.py` (parallel==sequential, sparsity, telescoping, STE gradient).
+- **Spyx commit:** record `git rev-parse HEAD` at run time.
+- **Date run:** 2026-07-06.

--- a/research/new/sigma_delta_neuron/sigma_delta_bench.py
+++ b/research/new/sigma_delta_neuron/sigma_delta_bench.py
@@ -1,0 +1,170 @@
+"""Sigma-delta vs rate-coded LIF: fewer transmitted events at matched accuracy.
+
+Claim: on **temporally-redundant** input (a slowly-varying signal), a sigma-delta
+graded neuron (``spyx.experimental.SigmaDelta``) reaches the same accuracy as a
+rate-coded ``spyx.nn.LIF`` while transmitting **far fewer events** — because it emits
+only the quantized *change* of its membrane, which is ~0 when the input is stable.
+Event rate is the device-agnostic energy proxy (each transmitted event is one synaptic
+op / packet, graded or binary). Also reports the ``.parallel`` associative-scan speedup.
+
+Honest caveats: a graded event carries more bits than a binary spike (so 'fewer events'
+is not the whole energy story); and on a dense GPU neither is sparse-exploited — the win
+is on event-driven / neuromorphic hardware. Self-contained synthetic task; no dataset.
+
+    SPYX_SMOKE=1 uv run python research/new/sigma_delta_neuron/sigma_delta_bench.py
+    uv run python research/new/sigma_delta_neuron/sigma_delta_bench.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from flax import nnx
+
+import spyx.axn as axn
+import spyx.bench as bench
+import spyx.fn as fn
+import spyx.nn as snn
+from spyx.experimental import SigmaDelta
+
+SMOKE = bool(os.environ.get("SPYX_SMOKE") or os.environ.get("SMOKE"))
+if SMOKE:
+    CHANNELS, HIDDEN, N_CLASSES, SAMPLE_T = 16, 24, 3, 40
+    N_TRAIN, BATCH, EPOCHS, SEEDS = 96, 32, 8, [0]
+else:
+    CHANNELS, HIDDEN, N_CLASSES, SAMPLE_T = 32, 64, 5, 80
+    N_TRAIN, BATCH, EPOCHS, SEEDS = 512, 64, 25, [0, 1]
+
+STEP = 0.5  # sigma-delta grid
+ce = fn.integral_crossentropy(smoothing=0.2)
+acc_fn = fn.integral_accuracy()
+
+
+def redundant_data(seed):
+    """Each class = a **step-and-hold**: the class band jumps to a constant level
+    early and holds it — genuinely temporally redundant (the regime sigma-delta is
+    for). A rate-coded LIF must keep firing through the hold; sigma-delta emits at the
+    step then goes silent.
+    """
+    rng = np.random.default_rng(seed)
+    band = max(1, CHANNELS // N_CLASSES)
+    t_on = SAMPLE_T // 4
+
+    def make(n):
+        y = rng.integers(0, N_CLASSES, size=n)
+        x = 0.05 * rng.standard_normal((n, SAMPLE_T, CHANNELS)).astype(np.float32)
+        for i in range(n):
+            lo = y[i] * band
+            x[i, t_on:, lo : lo + band] += 2.0  # step up, then HOLD constant to the end
+        return jnp.asarray(x), jnp.asarray(y.astype(np.int32))
+
+    def batched(x, y):
+        obs = [jnp.transpose(x[s : s + BATCH], (1, 0, 2)) for s in range(0, x.shape[0] - BATCH + 1, BATCH)]
+        lab = [y[s : s + BATCH] for s in range(0, x.shape[0] - BATCH + 1, BATCH)]
+        return obs, lab
+
+    return batched(*make(N_TRAIN)), batched(*make(N_TRAIN))
+
+
+def make_net(kind, rngs):
+    hidden = (
+        snn.LIF((HIDDEN,), activation=axn.superspike(), rngs=rngs)
+        if kind == "lif"
+        else SigmaDelta((HIDDEN,), step=STEP, rngs=rngs)
+    )
+    net = snn.Sequential(
+        nnx.Linear(CHANNELS, HIDDEN, rngs=rngs),
+        hidden,
+        nnx.Linear(HIDDEN, N_CLASSES, rngs=rngs),
+        snn.LI((N_CLASSES,), rngs=rngs),
+    )
+    return net
+
+
+def hidden_events(net, x_TBC):
+    """Mean fraction of NON-ZERO hidden events / step (the SOP proxy).
+
+    Scans the hidden neuron's ``__call__`` over the pre-activation so it works for both
+    the binary ``LIF`` (nonzero = spike) and the graded ``SigmaDelta`` (nonzero = event).
+    """
+    lin = net.layers[0]
+    neuron = net.layers[1]
+    pre = jnp.einsum("tbc,cd->tbd", x_TBC, lin.kernel.value) + lin.bias.value
+
+    def scan_step(V, xt):
+        s, V = neuron(xt, V)
+        return V, s
+
+    _, events = jax.lax.scan(scan_step, neuron.initial_state(pre.shape[1]), pre)
+    return float(jnp.mean(events != 0))
+
+
+def train_eval(kind, train, test, seed):
+    net = make_net(kind, nnx.Rngs(seed))
+    opt = nnx.Optimizer(net, optax.adam(3e-3), wrt=nnx.Param)
+
+    @nnx.jit
+    def step(net, opt, x, y):
+        def loss(m):
+            return ce(snn.run(m, x)[0].transpose(1, 0, 2), y)
+
+        loss_v, grads = nnx.value_and_grad(loss)(net)
+        opt.update(net, grads)
+        return loss_v
+
+    xs, ys = train
+    for _ in range(EPOCHS):
+        for x, y in zip(xs, ys, strict=True):
+            step(net, opt, x, y)
+
+    xt, yt = test
+    accs = [acc_fn(snn.run(net, x)[0].transpose(1, 0, 2), y)[0] for x, y in zip(xt, yt, strict=True)]
+    evs = [hidden_events(net, x) for x in xt]
+    return float(np.mean(accs)), float(np.mean(evs))
+
+
+def main():
+    print(f"backend={jax.default_backend()} SMOKE={SMOKE} redundant-signal task "
+          f"C={CHANNELS} H={HIDDEN} classes={N_CLASSES} T={SAMPLE_T} step={STEP}", flush=True)
+    t0 = time.perf_counter()
+    rows = {}
+    for kind in ["lif", "sigma_delta"]:
+        accs, evs = [], []
+        for seed in SEEDS:
+            tr, te = redundant_data(seed)
+            a, e = train_eval(kind, tr, te, seed)
+            accs.append(a)
+            evs.append(e)
+        rows[kind] = {"acc": float(np.mean(accs)), "event_rate": float(np.mean(evs))}
+        print(f"  {kind:12s} acc={np.mean(accs) * 100:5.1f}%  event_rate={np.mean(evs) * 100:5.1f}%", flush=True)
+
+    ev_ratio = rows["lif"]["event_rate"] / max(rows["sigma_delta"]["event_rate"], 1e-9)
+    print(f"  -> event reduction (LIF / sigma-delta) = {ev_ratio:.2f}x "
+          f"at {rows['sigma_delta']['acc'] * 100:.1f}% vs {rows['lif']['acc'] * 100:.1f}%", flush=True)
+
+    # .parallel speedup of the sigma-delta neuron itself
+    print("\n== sigma-delta .parallel vs sequential (spyx.bench) ==", flush=True)
+    speed = bench.compare(
+        {"SigmaDelta": lambda: SigmaDelta((HIDDEN,), step=STEP, rngs=nnx.Rngs(0))},
+        (HIDDEN,), seq_lens=[SAMPLE_T], batch=BATCH, backward=False, n_iters=10,
+    )
+    print(bench.format_table(speed), flush=True)
+    dt = time.perf_counter() - t0
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "sigma_delta_results.json"), "w") as f:
+        json.dump({"config": {"smoke": SMOKE, "device": str(jax.devices()[0]),
+                              "channels": CHANNELS, "hidden": HIDDEN, "n_classes": N_CLASSES,
+                              "sample_T": SAMPLE_T, "step": STEP, "seeds": SEEDS, "wall_s": dt},
+                   "arms": rows, "event_reduction_x": ev_ratio}, f, indent=2)
+    print(f"\nwrote sigma_delta_results.json  ({dt:.0f}s)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/new/sigma_delta_neuron/sigma_delta_results.json
+++ b/research/new/sigma_delta_neuron/sigma_delta_results.json
@@ -1,0 +1,27 @@
+{
+  "config": {
+    "smoke": false,
+    "device": "rocm:0",
+    "channels": 32,
+    "hidden": 64,
+    "n_classes": 5,
+    "sample_T": 80,
+    "step": 0.5,
+    "seeds": [
+      0,
+      1
+    ],
+    "wall_s": 24.81659023600514
+  },
+  "arms": {
+    "lif": {
+      "acc": 0.994140625,
+      "event_rate": 0.11017284588888288
+    },
+    "sigma_delta": {
+      "acc": 0.998046875,
+      "event_rate": 0.028721237438730896
+    }
+  },
+  "event_reduction_x": 3.8359366000127006
+}

--- a/src/spyx/experimental/__init__.py
+++ b/src/spyx/experimental/__init__.py
@@ -18,6 +18,13 @@ Contents:
   ``AssociativeLeaky``, which is a different matrix-state associative-memory SSM.
 - :class:`~spyx.experimental.ResonateFire` — complex resonate-and-fire oscillatory
   neuron. *Physically defined in* ``spyx.phasor``.
+- :class:`~spyx.experimental.ParallelResetLIF` — reset-*preserving* parallel LIF
+  (FPT fixed-point scan: keeps the exact hard reset while parallelising the time loop).
+- :class:`~spyx.experimental.RFSSM` — resonate-and-fire as a scaled spiking SSM
+  (S5/HiPPO pole init + PRF decoupled reset; alias ``ResonateFireSSM``).
+- :class:`~spyx.experimental.SigmaDelta` — graded sigma-delta neuron that transmits
+  only the quantized *change* in its membrane, so temporally-redundant input is nearly
+  free (``graded_quant`` is the straight-through grid quantiser).
 - :mod:`spyx.experimental.raven` — Routing Slot Memories (``RavenRSM``) and the
   spiking sibling ``SpikingSlotMemory``, after Raven (Afzal, Bick, Xing, Cevher,
   Gu 2026). Plus ``SlotRouter`` and the ``make_recall_batch`` MQAR generator.
@@ -56,6 +63,7 @@ from . import (
     parallel_reset,
     raven,
     rf_ssm,
+    sigma_delta,
     stochastic,
     zoo,
 )
@@ -71,6 +79,7 @@ from .hybrid import (
 from .parallel_reset import ParallelResetLIF
 from .raven import RavenRSM, SlotRouter, SpikingSlotMemory, make_recall_batch
 from .rf_ssm import RFSSM, ResonateFireSSM
+from .sigma_delta import SigmaDelta, graded_quant
 from .stochastic import (
     SPSN,
     StochasticAssociativeCuBaLIF,
@@ -88,11 +97,14 @@ __all__ = [
     "parallel_reset",
     "raven",
     "rf_ssm",
+    "sigma_delta",
     "stochastic",
     "zoo",
     "ParallelResetLIF",
     "RFSSM",
     "ResonateFireSSM",
+    "SigmaDelta",
+    "graded_quant",
     "PSU_LIF",
     "AssociativeLIF",
     "ResonateFire",

--- a/src/spyx/experimental/sigma_delta.py
+++ b/src/spyx/experimental/sigma_delta.py
@@ -1,0 +1,116 @@
+r"""Sigma-delta / graded-spike neuron — transmit only the *change* in activation.
+
+A rate-coded spiking neuron fires on the *level* of its drive, so a slowly-varying
+(temporally redundant) input still costs a steady stream of spikes. A **sigma-delta**
+neuron instead integrates its input into a leaky membrane and emits the **quantized
+change** of that membrane each step. When the membrane is stable the change rounds to
+zero and *nothing is transmitted*, so redundant input is nearly free — the efficiency
+mechanism behind Loihi-2's graded/sigma-delta mode.
+
+The membrane is the same reset-free linear recurrence as
+:class:`spyx.experimental.PSU_LIF`, ``V_t = beta V_{t-1} + x_t`` — so it is an
+``O(log T)`` :func:`jax.lax.associative_scan` (the graded event is a pointwise
+function of consecutive membrane values). The output is a **graded** event: a
+signed, quantized real value (the change), mostly zero, not a binary spike. Its time
+integral telescopes back to the membrane (``sum_t s_t = V_T``), so a downstream layer
+recovers the integrated signal by accumulation — the standard sigma-delta dataflow.
+
+References:
+
+* O'Connor & Welling, *Sigma-Delta Quantized Networks*, ICLR 2017
+  (`arXiv:1611.02024 <https://arxiv.org/abs/1611.02024>`_).
+* Shrestha et al., efficient audio/video on Loihi 2 via resonate-and-fire +
+  sigma-delta, ICASSP 2024 (`arXiv:2310.03251 <https://arxiv.org/abs/2310.03251>`_).
+
+This is the reset-free *graded* sibling of the binary parallel neurons; its ``.parallel``
+path and its per-step ``__call__`` are exactly equivalent, like ``PSU_LIF``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from ..nn import _leaky_associative_op
+
+
+def graded_quant(delta: jax.Array, step: float) -> jax.Array:
+    """Quantize ``delta`` to the grid ``step`` with a straight-through gradient.
+
+    Forward: ``round(delta / step) * step`` — the graded sigma-delta event, which is
+    exactly zero whenever ``|delta| < step/2`` (the source of the sparsity). Backward:
+    identity (straight-through), the standard estimator for a round nonlinearity.
+    """
+
+    @jax.custom_gradient
+    def _q(d):
+        out = jnp.round(d / step) * step
+        return out, lambda g: g
+
+    return _q(delta)
+
+
+class SigmaDelta(nnx.Module):
+    r"""Sigma-delta graded-spike neuron.
+
+    Membrane ``V_t = clip(beta) V_{t-1} + x_t`` (reset-free, the same recurrence as
+    :class:`spyx.experimental.PSU_LIF`); output ``s_t = graded_quant(V_t - V_{t-1})``.
+    Follows the ``(x, state) -> (out, new_state)`` contract, so it drops into
+    :class:`spyx.nn.Sequential` / :func:`spyx.nn.run`.
+
+    :hidden_shape: per-neuron feature shape.
+    :beta: membrane leak. Scalar constant if provided, else a learnable per-unit init
+        (truncated-normal around 0.5, clipped to ``[0, 1]`` each forward), matching
+        ``PSU_LIF``.
+    :step: quantization grid of the graded event. Larger ``step`` → sparser, coarser
+        events; smaller → denser, finer. Fixed (not learned) to keep the event grid
+        stable.
+
+    Honest caveat: this is the *feedforward* delta form (the quantization error is not
+    fed back), so the reconstructed signal can drift by ``O(sqrt(T) * step)`` over long
+    sequences. A closed-loop (error-feedback) variant is drift-free but sequential — a
+    deliberate parallelism trade-off, as with the reset in ``PSU_LIF`` vs ``LIF``.
+    """
+
+    def __init__(
+        self, hidden_shape: tuple, beta=None, step: float = 1.0, *, rngs: nnx.Rngs
+    ):
+        self.hidden_shape = hidden_shape
+        self.step = float(step)
+        if beta is None:
+            self.beta = nnx.Param(
+                nnx.initializers.truncated_normal(stddev=0.25)(
+                    rngs.params(), hidden_shape
+                )
+                + 0.5
+            )
+        else:
+            self.beta = nnx.Param(jnp.full((), beta))
+
+    def __call__(self, x, V):
+        """One reset-free step ``(x, V) -> (graded_event, V_new)``.
+
+        Scanning this over time via :func:`spyx.nn.run` reproduces :meth:`parallel`
+        exactly (same clipped ``beta``, same grid).
+        """
+        beta = jnp.clip(self.beta[...], 0, 1)
+        V_new = beta * V + x
+        s = graded_quant(V_new - V, self.step)
+        return s, V_new
+
+    def initial_state(self, batch_size):
+        return jnp.zeros((batch_size,) + tuple(self.hidden_shape))
+
+    def parallel(self, x):
+        r"""Score a whole time-major ``[T, B, ...]`` sequence with an associative scan.
+
+        Builds the membrane trace ``V`` (``V_{-1} = 0``) via
+        :func:`jax.lax.associative_scan` in ``O(log T)`` depth, then emits the graded
+        change ``graded_quant(V_t - V_{t-1})`` pointwise.
+        """
+        beta = jnp.clip(self.beta[...], 0, 1)
+        A = jnp.broadcast_to(beta, x.shape)
+        _, V = jax.lax.associative_scan(_leaky_associative_op, (A, x), axis=0)
+        V_prev = jnp.concatenate([jnp.zeros_like(V[:1]), V[:-1]], axis=0)
+        return graded_quant(V - V_prev, self.step)

--- a/tests/test_sigma_delta.py
+++ b/tests/test_sigma_delta.py
@@ -1,0 +1,102 @@
+"""Sigma-delta / graded-spike neuron: equivalence, sparsity, telescoping, gradients."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+import spyx.nn as snn
+from spyx.experimental import SigmaDelta, graded_quant
+
+
+def _seq_scan(neuron, x):
+    """Reference: scan ``__call__`` over time -> stacked graded events."""
+    V = neuron.initial_state(x.shape[1])
+    outs = []
+    for t in range(x.shape[0]):
+        s, V = neuron(x[t], V)
+        outs.append(s)
+    return jnp.stack(outs)
+
+
+@pytest.mark.parametrize("beta", [0.5, 0.9])
+@pytest.mark.parametrize("step", [0.25, 1.0])
+def test_parallel_equals_sequential(beta, step):
+    """The `.parallel` associative-scan path == scanning `__call__` over time."""
+    T, B, C = 40, 8, 16
+    neuron = SigmaDelta((C,), beta=beta, step=step, rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.PRNGKey(1), (T, B, C))
+    s_par = neuron.parallel(x)
+    s_seq = _seq_scan(neuron, x)
+    assert float(jnp.max(jnp.abs(s_par - s_seq))) < 1e-5
+
+
+def test_sparse_on_redundant_input():
+    """A constant (temporally redundant) input -> membrane settles -> events vanish."""
+    T, B, C = 60, 4, 32
+    neuron = SigmaDelta((C,), beta=0.8, step=0.5, rngs=nnx.Rngs(0))
+    x_const = jnp.broadcast_to(jnp.ones((C,)), (T, B, C))
+    s = neuron.parallel(x_const)
+    # after the transient, the membrane is stable so nearly all events are zero.
+    late_sparsity = float(jnp.mean(s[T // 2 :] == 0))
+    assert late_sparsity > 0.9
+
+    # a noisy (non-redundant) input transmits strictly more events than the constant one.
+    x_noisy = jax.random.normal(jax.random.PRNGKey(2), (T, B, C)) * 2.0
+    s_noisy = neuron.parallel(x_noisy)
+    assert float(jnp.mean(s_noisy != 0)) > float(jnp.mean(s != 0))
+
+
+def test_telescoping_reconstruction():
+    """Graded events integrate back to the membrane: cumsum(s)_t tracks V_t."""
+    T, B, C = 50, 4, 16
+    beta, step = 0.9, 0.05  # fine grid -> tight tracking
+    neuron = SigmaDelta((C,), beta=beta, step=step, rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.PRNGKey(3), (T, B, C))
+    # membrane trace via the same scan the neuron uses
+    A = jnp.broadcast_to(beta, x.shape)
+    _, V = jax.lax.associative_scan(snn._leaky_associative_op, (A, x), axis=0)
+    recon = jnp.cumsum(neuron.parallel(x), axis=0)
+    # feedforward delta form: per-step error <= step/2, drift ~ sqrt(T)*step.
+    assert float(jnp.max(jnp.abs(recon - V))) < 3.0 * step * np.sqrt(T)
+
+
+def test_graded_quant_is_sparse_and_ste():
+    """graded_quant rounds to the grid (zero in the dead-zone) with an STE gradient."""
+    d = jnp.array([0.0, 0.1, 0.4, 0.6, -0.6, 2.3])
+    q = graded_quant(d, 1.0)
+    # |d| < 0.5 rounds to 0 (the sparsity dead-zone); else to the nearest grid point.
+    assert jnp.allclose(q, jnp.array([0.0, 0.0, 0.0, 1.0, -1.0, 2.0]))
+    # straight-through: gradient of the (piecewise-constant) round is passed through as 1.
+    g = jax.grad(lambda z: jnp.sum(graded_quant(z, 1.0)))(d)
+    assert jnp.allclose(g, jnp.ones_like(d))
+
+
+def test_drops_into_sequential_run():
+    """SigmaDelta honours the (x, state) -> (out, new_state) contract via spyx.nn.run."""
+    T, B, C, H = 20, 4, 8, 12
+    net = snn.Sequential(
+        nnx.Linear(C, H, rngs=nnx.Rngs(0)),
+        SigmaDelta((H,), beta=0.9, step=0.5, rngs=nnx.Rngs(1)),
+        nnx.Linear(H, 3, rngs=nnx.Rngs(2)),
+        snn.LI((3,), rngs=nnx.Rngs(3)),
+    )
+    x = jax.random.normal(jax.random.PRNGKey(4), (T, B, C))
+    out, _ = snn.run(net, x)
+    assert out.shape == (T, B, 3)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_beta_gradient_flows():
+    """STE lets a gradient reach the learnable leak through the quantizer."""
+    T, B, C = 16, 4, 8
+    neuron = SigmaDelta((C,), step=0.5, rngs=nnx.Rngs(0))  # learnable per-unit beta
+    x = jax.random.normal(jax.random.PRNGKey(5), (T, B, C))
+
+    def loss(m):
+        return jnp.mean(m.parallel(x) ** 2)
+
+    grads = nnx.grad(loss)(neuron)
+    leaves = [jnp.asarray(g) for g in jax.tree.leaves(grads)]
+    assert leaves and any(bool(jnp.any(g != 0.0)) for g in leaves)


### PR DESCRIPTION
A **graded sigma-delta neuron** — transmits only the quantized *change* of its leaky membrane, so temporally-redundant (held) input is nearly free. The efficiency mechanism behind Loihi-2's sigma-delta mode, and the **first clean JAX/Flax graded neuron**.

- Reset-free membrane (same recurrence as `PSU_LIF`) → honours the `(x,state)->(out,new_state)` contract (drops into `Sequential`/`run`) and **parallelises with an `associative_scan`** (`.parallel` == sequential). `graded_quant` is a straight-through grid quantiser (zero in the `|d|<step/2` dead-zone → the sparsity).
- Prior art (change-transmission): O'Connor & Welling ICLR 2017 (arXiv:1611.02024); Shrestha et al. Loihi-2 ICASSP 2024 (arXiv:2310.03251). Reference impl is Intel `lava-dl` (PyTorch); no JAX graded neuron existed.
- **9 tests**: parallel==sequential, sparsity-on-redundant-input, telescoping reconstruction, STE gradient, `Sequential` contract.

## Study (research/new/sigma_delta_neuron/), full 8060S run
| Neuron | acc | event rate |
|---|---|---|
| LIF | 99.4% | 11.0% |
| **SigmaDelta** | **99.8%** | **2.9%** |

**3.84× fewer transmitted events at matched accuracy** on a step-and-hold redundant task. Honest caveats in the README: win is redundancy-dependent (not on continuously-varying input); graded events carry more bits than binary spikes; dense GPU doesn't exploit the sparsity (the win is event-driven-HW); feedforward delta drifts `O(√T·step)`.

Toward *"spyx great for efficient sequence models"*: a graded, parallelizable, inference-efficient neuron alongside the binary / reset-free / reset-preserving family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)