### PR TITLE
Sparse + quantized activation packing (spyx.experimental.compress)

### DIFF
--- a/docs/explanation/substrate-and-the-hardware-lottery.md
+++ b/docs/explanation/substrate-and-the-hardware-lottery.md
@@ -122,8 +122,14 @@ why MoE routing and block-sparse attention are dense-within-block. So the user
 intuition ("skip empty sections of spiking data") is the right *goal*; the
 engineering reality is it must be made **coarse and structured** to beat dense.
 spyx already holds the storage half of this — bit-packed spikes in
-[`spyx.experimental.compress`](../reference/experimental.md) — the missing half is a
-block-sparse consumer kernel.
+[`spyx.experimental.compress`](../reference/experimental.md), now generalised to
+**quantized + sparse** activations: pack at *k* bits (`pack_nbit`,
+`packed_quant_dense`) for graded/low-precision events, or store a 1-bit occupancy
+mask plus only the nonzero codes (`sparse_quant_pack`) — which beats dense *k*-bit
+packing below a density of `(bits-1)/bits` (see
+[`research/new/activation_packing/`](https://github.com/kmheckel/spyx/tree/main/research/new/activation_packing)).
+That is the storage/transmission win; the missing half is still a block-sparse
+consumer kernel that turns the saved bytes into skipped matmuls.
 
 ## Does matmul-free lose to NVFP4?
 

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -26,6 +26,7 @@ FP4×SNN gap and its neighbours).
 | [honest_energy_accounting](new/honest_energy_accounting/) | Honest (memory-inclusive, QANN-baselined) SNN energy accounting | ✅ | new | crossover 5.99% ≈ literature 6.4%; SOP proxy under-reports ~700× |
 | [quant_aware_evolution](new/quant_aware_evolution/) | Gradient-free ES beats STE-QAT at extreme precision (no STE bias) | ➖ | new | null on easy task |
 | [quant_aware_evolution_hard](new/quant_aware_evolution_hard/) | The STE-bias gap appears once quantization costs accuracy | ❌ | new | reversed: ES *breaks* at ternary (coarse rounding flattens the ES landscape) |
+| [activation_packing](new/activation_packing/) | Sparse+quantized activations pack exactly; mask+value beats dense k-bit below a density crossover | ✅ | experimental | `spyx.experimental.compress`: k-bit `pack_nbit`/`packed_quant_dense` + `sparse_quant_pack`; crossover `(bits-1)/bits` confirmed 18/18; 5.3× vs fp32 BPTT residual |
 
 ### Parallel spiking neurons
 

--- a/research/new/activation_packing/README.md
+++ b/research/new/activation_packing/README.md
@@ -1,0 +1,107 @@
+# Packing sparse + quantized activations: exactness, footprint, crossover
+
+## Title
+
+`spyx.experimental.compress` — bit-plane packing of **quantized** activations
+(`pack_nbit` / `packed_quant_dense`) and **sparse + quantized** activations
+(`sparse_quant_pack`), generalising the binary-spike `packed_spike_dense`.
+
+## Paper & arXiv/DOI
+
+- **Title:** Spyx utility; the mechanisms are standard. Not a paper claim.
+- **Prior art:** bit-plane / bit-slice packing is classic; run-length / mask+value
+  (a.k.a. bitmap or "occupancy") sparse formats are standard (CSR/COO cousins);
+  microscaling low-bit grids follow the OCP MX spec. The contribution here is a small,
+  **exact, JAX-native** activation-packing layer wired into BPTT for spiking / graded
+  neurons — the binary case (`packed_spike_dense`) already lived in Spyx; this adds the
+  k-bit and sparse axes.
+- **Bucket:** new
+
+## Claim under test
+
+Two independent knobs cut activation memory, and the layer is **exact** on grid-quantized
+activations:
+
+1. **Quantization axis** — packing at `bits` bits stores `bits/8` B/element, a `32/bits×`
+   cut vs fp32; `packed_quant_dense` uses that as the BPTT residual and reproduces the
+   naive dense's forward and both gradients (up to fp32 rounding).
+2. **Sparsity axis** — a 1-bit occupancy mask + only the nonzero codes costs
+   `ceil(N/8) + ceil(nnz·bits/8)` bytes, which **beats dense k-bit packing below a
+   density of `(bits-1)/bits`** and loses above it.
+
+## Method
+
+Self-contained; the interesting numbers are byte counts (hardware-independent) and
+exactness checks. Three parts:
+
+- **A. Exactness** — `sparse_quant_pack → sparse_quant_unpack` roundtrip is bit-exact,
+  and `packed_quant_dense` gradients (w.r.t. activations and weight) match the naive
+  `a @ w` on grid-quantized inputs.
+- **B. Footprint sweep** — for each `bits ∈ {2,4,8}` × `density ∈ {0.02…0.9}`, the
+  *empirical* packed `nbytes` of the dense-k-bit and sparse schemes, checked against the
+  analytic `packing_footprint`, and which scheme wins (the crossover).
+- **C. BPTT residual** — a real graded `SigmaDelta` hidden activation: fp32 residual
+  bytes (what a naive matmul stashes) vs the dense-k-bit and sparse packed forms.
+
+## Spyx modules used
+
+- [`spyx.experimental.compress`](../../../src/spyx/experimental/compress.py) —
+  `pack_nbit`/`unpack_nbit`, `packed_quant_dense`, `sparse_quant_pack`/`sparse_quant_unpack`,
+  `packing_footprint`
+- [`spyx.experimental.SigmaDelta`](../../../src/spyx/experimental/sigma_delta.py), [`spyx.nn`](../../../src/spyx/nn.py)
+
+## How to run
+
+```bash
+SPYX_SMOKE=1 uv run python research/new/activation_packing/activation_packing_bench.py
+uv run python research/new/activation_packing/activation_packing_bench.py
+```
+
+Writes `activation_packing_results.json`.
+
+## Findings
+
+**A. Exact.** Roundtrip is bit-exact for every width; `packed_quant_dense` gradients match
+the naive dense to fp32 rounding (`max abs err ≈ 2e-3` on gradients of magnitude ~10²,
+i.e. ~1e-5 relative). The correctness tests live in `tests/test_compress.py`.
+
+**B. The crossover is exactly `(bits-1)/bits`, confirmed empirically at N=2²⁰** (bytes):
+
+| bits | density | dense k-bit | sparse mask+code | winner |
+| ---: | ---: | ---: | ---: | :--- |
+| 4 | 0.10 | 524 288 | 180 272 | **sparse** (2.9× smaller) |
+| 4 | 0.25 | 524 288 | 253 356 | **sparse** (2.1×) |
+| 4 | 0.75 | 524 288 | 498 484 | **sparse** (just barely) |
+| 4 | 0.90 | 524 288 | 571 260 | **dense** |
+| 8 | 0.10 | 1 048 576 | 235 272 | **sparse** (4.5×) |
+| 8 | 0.90 | 1 048 576 | 1 070 552 | **dense** |
+
+Empirical-vs-analytic winner mismatches: **0/18**. Sparse wins big at low density and at
+higher bit-widths (the mask overhead is amortised over fatter codes); dense k-bit wins
+once the tensor is nearly full. The `(bits-1)/bits` rule: at 4-bit, mask+value pays off
+below 75% density; at 8-bit, below 87.5%.
+
+**C. On a real (dense, random-input) sigma-delta activation** — 91% nonzero, a 6-bit
+grid — dense k-bit packing gives **5.3× vs fp32** and edges out sparse (4.9×), exactly as
+the crossover predicts for a nearly-full tensor. The sparse scheme's win is realised on
+**temporally-redundant** input, where the sigma-delta event density collapses (see
+[`../sigma_delta_neuron/`](../sigma_delta_neuron/): 2.9% events) — deep inside the
+sparse-wins regime, where `sparse_quant_pack` would give an order-of-magnitude cut.
+
+**Honest caveats.** (1) This is a **memory / transmission** win, not a compute win: on a
+dense GPU the pack/unpack is *extra* work and nothing is sparsity-skipped — the payoff is
+BPTT activation memory, event-driven transmission, and neuromorphic targets. (2) Exactness
+requires the activations to lie on the quantization grid; packing off-grid floats
+silently rounds them (fine for graded/spiking events, wrong for arbitrary tensors).
+(3) `sparse_quant_pack` is eager (dynamic nonzero count) — for storage/transmission, not a
+jit hot loop; `packed_quant_dense`/`pack_nbit` are jit-friendly. (4) First-order VJP only.
+
+## Reproducibility
+
+- **Seeds:** `jax.random.PRNGKey` throughout; `nnx.Rngs(seed)` for the net in part C.
+- **JAX / hardware:** part B is byte counts (hardware-independent); parts A/C run on CPU
+  or GPU. Device recorded in the JSON.
+- **Correctness:** `tests/test_compress.py` (roundtrip exactness, `packed_quant_dense`
+  gradient equivalence, footprint crossover).
+- **Spyx commit:** record `git rev-parse HEAD` at run time.
+- **Date run:** 2026-07-06.

--- a/research/new/activation_packing/activation_packing_bench.py
+++ b/research/new/activation_packing/activation_packing_bench.py
@@ -1,0 +1,236 @@
+"""Packing sparse + quantized activations: exactness, footprint, and the crossover.
+
+Binary spikes are the ``k=1`` corner of activation packing. This study measures the
+two-axis generalisation in ``spyx.experimental.compress``:
+
+  * **quantization** — pack activations at ``bits`` bits with ``pack_nbit`` (bit-plane
+    packing); ``packed_quant_dense`` is the k-bit BPTT residual (a ``32/bits×`` cut of the
+    dominant activation memory), exact for grid-quantized activations.
+  * **sparsity** — store a 1-bit occupancy mask plus only the nonzero codes
+    (``sparse_quant_pack``). Footprint ``ceil(N/8) + ceil(nnz·bits/8)`` bytes, which beats
+    dense k-bit packing below the ``(bits-1)/bits`` density crossover.
+
+Reports, all from real arrays (no hand-waved numbers):
+  A. exactness — roundtrip is bit-exact and ``packed_quant_dense`` grads == naive dense.
+  B. footprint sweep — empirical packed ``nbytes`` vs the analytic ``packing_footprint``
+     model over density × bit-width, and which scheme wins where (the crossover).
+  C. BPTT residual saving on a real graded sigma-delta activation.
+
+Honest framing: this is a **memory** win (activation residual / storage / transmission),
+not a compute win — on a dense GPU the pack/unpack is extra work and nothing is
+sparsity-skipped; the payoff is BPTT memory, event-driven transmission, and neuromorphic
+targets. Exactness holds only for grid-quantized inputs.
+
+    SPYX_SMOKE=1 uv run python research/new/activation_packing/activation_packing_bench.py
+    uv run python research/new/activation_packing/activation_packing_bench.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+
+import spyx.nn as snn
+from spyx.experimental import SigmaDelta
+from spyx.experimental.compress import (
+    pack_nbit,
+    packed_quant_dense,
+    packing_footprint,
+    sparse_quant_pack,
+    sparse_quant_unpack,
+)
+
+SMOKE = bool(os.environ.get("SPYX_SMOKE") or os.environ.get("SMOKE"))
+N_ELEM = 4096 if SMOKE else 1 << 20
+DENSITIES = [0.02, 0.1, 0.25, 0.5, 0.75, 0.9]
+BITWIDTHS = [2, 4, 8]
+STEP = 0.25
+
+
+def _grid(key, shape, bits, density):
+    """A sparse, grid-quantized tensor: `density` fraction nonzero, values on the
+    symmetric `step`-spaced grid representable in `bits` signed levels."""
+    hi = 1 << (bits - 1)
+    codes = jax.random.randint(key, shape, -hi + 1, hi).astype(jnp.float32)
+    keep = jax.random.uniform(jax.random.fold_in(key, 1), shape) < density
+    return jnp.where(keep, codes * STEP, 0.0)
+
+
+def part_a_exactness():
+    """Roundtrip is bit-exact; packed_quant_dense grads match the naive dense."""
+    ok_roundtrip, max_grad_err = True, 0.0
+    for bits in BITWIDTHS:
+        x = _grid(jax.random.PRNGKey(bits), (8, 64), bits, 0.3)
+        mp, cp, meta = sparse_quant_pack(x, bits, STEP)
+        if not bool(jnp.array_equal(sparse_quant_unpack(mp, cp, meta), x)):
+            ok_roundtrip = False
+        # gradient equivalence of the k-bit BPTT dense on grid-quantized acts
+        w = jax.random.normal(jax.random.PRNGKey(bits + 9), (64, 10))
+        tgt = jax.random.normal(jax.random.PRNGKey(bits + 99), (8, 10))
+
+        def lp(a, w):
+            return jnp.sum((packed_quant_dense(a, w, bits, STEP) - tgt) ** 2)
+
+        def ln(a, w):
+            return jnp.sum((a @ w - tgt) ** 2)
+
+        gp = jax.grad(lp, argnums=(0, 1))(x, w)
+        gn = jax.grad(ln, argnums=(0, 1))(x, w)
+        max_grad_err = max(
+            max_grad_err,
+            float(jnp.max(jnp.abs(gp[0] - gn[0]))),
+            float(jnp.max(jnp.abs(gp[1] - gn[1]))),
+        )
+    return {"roundtrip_bit_exact": ok_roundtrip, "max_grad_abs_err": max_grad_err}
+
+
+def part_b_footprint():
+    """Empirical packed nbytes vs the analytic model; report the winning scheme."""
+    rows = []
+    for bits in BITWIDTHS:
+        for d in DENSITIES:
+            x = _grid(jax.random.PRNGKey(int(d * 1000) + bits), (N_ELEM,), bits, d)
+            # empirical bytes actually occupied by each packed representation
+            dense_bits = int(
+                pack_nbit(jnp.zeros_like(x).astype(jnp.uint32), bits).nbytes
+            )
+            mp, cp, _ = sparse_quant_pack(x, bits, STEP)
+            sparse_bytes = int(mp.nbytes) + int(cp.nbytes)
+            model = packing_footprint(N_ELEM, bits, float(jnp.mean(x != 0)))
+            emp_best = "sparse" if sparse_bytes < dense_bits else "dense"
+            rows.append(
+                {
+                    "bits": bits,
+                    "density": d,
+                    "dense_kbit_bytes": dense_bits,
+                    "sparse_bytes": sparse_bytes,
+                    "model_best": model["best"],
+                    "empirical_best": emp_best,
+                    "crossover_density": model["crossover_density"],
+                }
+            )
+    return rows
+
+
+def part_c_bptt_residual():
+    """Real graded sigma-delta activation: fp32 residual bytes vs packed k-bit codes."""
+    T, B, C, H = (8, 8, 16, 24) if SMOKE else (60, 64, 64, 128)
+    net = snn.Sequential(
+        nnx.Linear(C, H, rngs=nnx.Rngs(0)),
+        SigmaDelta((H,), step=STEP, rngs=nnx.Rngs(1)),
+        nnx.Linear(H, 4, rngs=nnx.Rngs(2)),
+        snn.LI((4,), rngs=nnx.Rngs(3)),
+    )
+    x = jax.random.normal(jax.random.PRNGKey(7), (T, B, C))
+    lin, neuron = net.layers[0], net.layers[1]
+    pre = jnp.einsum("tbc,cd->tbd", x, lin.kernel[...]) + lin.bias[...]
+
+    def scan_step(V, xt):
+        s, V = neuron(xt, V)
+        return V, s
+
+    _, events = jax.lax.scan(scan_step, neuron.initial_state(B), pre)  # (T,B,H) graded
+    density = float(jnp.mean(events != 0))
+    # what a naive matmul stashes for the backward residual (fp32) vs the packed forms
+    fp32_bytes = int(events.astype(jnp.float32).nbytes)
+    # graded events sit on the `step` grid; find the bits needed to index the levels used
+    codes = jnp.round(events / STEP).astype(jnp.int32)
+    span = int(jnp.max(codes) - jnp.min(codes)) + 1
+    bits = max(1, int(np.ceil(np.log2(max(span, 2)))))
+    dense_kbit_bytes = int(
+        pack_nbit(jnp.zeros_like(events).astype(jnp.uint32), bits).nbytes
+    )
+    mp, cp, _ = sparse_quant_pack(events, bits, STEP)
+    sparse_bytes = int(mp.nbytes) + int(cp.nbytes)
+    return {
+        "shape_TBH": [T, B, H],
+        "event_density": density,
+        "grid_bits": bits,
+        "fp32_residual_bytes": fp32_bytes,
+        "dense_kbit_bytes": dense_kbit_bytes,
+        "sparse_bytes": sparse_bytes,
+        "dense_vs_fp32_x": fp32_bytes / max(dense_kbit_bytes, 1),
+        "sparse_vs_fp32_x": fp32_bytes / max(sparse_bytes, 1),
+    }
+
+
+def main():
+    print(
+        f"backend={jax.default_backend()} SMOKE={SMOKE} N={N_ELEM} step={STEP}",
+        flush=True,
+    )
+
+    a = part_a_exactness()
+    print(
+        f"\n[A] exactness: roundtrip_bit_exact={a['roundtrip_bit_exact']} "
+        f"max_grad_abs_err={a['max_grad_abs_err']:.2e}",
+        flush=True,
+    )
+
+    b = part_b_footprint()
+    print("\n[B] footprint sweep (bytes; winner in bold sense):", flush=True)
+    print(
+        f"    {'bits':>4} {'density':>8} {'dense_kbit':>11} {'sparse':>10} {'winner':>8}",
+        flush=True,
+    )
+    mism = 0
+    for r in b:
+        # model_best is like 'sparse_mask+4bit' or 'dense_4bit'; empirical_best is
+        # 'sparse'/'dense'. They should always agree (the analytic model is exact).
+        if r["empirical_best"] not in r["model_best"]:
+            mism += 1
+        print(
+            f"    {r['bits']:>4} {r['density']:>8.2f} {r['dense_kbit_bytes']:>11} "
+            f"{r['sparse_bytes']:>10} {r['empirical_best']:>8}",
+            flush=True,
+        )
+    print(
+        f"    empirical-vs-model winner mismatches: {mism} (crossover at (bits-1)/bits)",
+        flush=True,
+    )
+
+    c = part_c_bptt_residual()
+    print(
+        f"\n[C] BPTT residual on real sigma-delta activation "
+        f"(density={c['event_density'] * 100:.1f}%, {c['grid_bits']}-bit grid):",
+        flush=True,
+    )
+    print(f"    fp32 residual   : {c['fp32_residual_bytes']:>10} B", flush=True)
+    print(
+        f"    dense k-bit pack: {c['dense_kbit_bytes']:>10} B  ({c['dense_vs_fp32_x']:.1f}× vs fp32)",
+        flush=True,
+    )
+    print(
+        f"    sparse mask+code: {c['sparse_bytes']:>10} B  ({c['sparse_vs_fp32_x']:.1f}× vs fp32)",
+        flush=True,
+    )
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(here, "activation_packing_results.json"), "w") as f:
+        json.dump(
+            {
+                "config": {
+                    "smoke": SMOKE,
+                    "device": str(jax.devices()[0]),
+                    "n_elem": N_ELEM,
+                    "step": STEP,
+                    "densities": DENSITIES,
+                    "bitwidths": BITWIDTHS,
+                },
+                "exactness": a,
+                "footprint_sweep": b,
+                "bptt_residual": c,
+            },
+            f,
+            indent=2,
+        )
+    print("\nwrote activation_packing_results.json", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/new/activation_packing/activation_packing_results.json
+++ b/research/new/activation_packing/activation_packing_results.json
@@ -1,0 +1,203 @@
+{
+  "config": {
+    "smoke": true,
+    "device": "cpu:0",
+    "n_elem": 4096,
+    "step": 0.25,
+    "densities": [
+      0.02,
+      0.1,
+      0.25,
+      0.5,
+      0.75,
+      0.9
+    ],
+    "bitwidths": [
+      2,
+      4,
+      8
+    ]
+  },
+  "exactness": {
+    "roundtrip_bit_exact": true,
+    "max_grad_abs_err": 0.001953125
+  },
+  "footprint_sweep": [
+    {
+      "bits": 2,
+      "density": 0.02,
+      "dense_kbit_bytes": 1024,
+      "sparse_bytes": 526,
+      "model_best": "sparse_mask+2bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.5
+    },
+    {
+      "bits": 2,
+      "density": 0.1,
+      "dense_kbit_bytes": 1024,
+      "sparse_bytes": 576,
+      "model_best": "sparse_mask+2bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.5
+    },
+    {
+      "bits": 2,
+      "density": 0.25,
+      "dense_kbit_bytes": 1024,
+      "sparse_bytes": 682,
+      "model_best": "sparse_mask+2bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.5
+    },
+    {
+      "bits": 2,
+      "density": 0.5,
+      "dense_kbit_bytes": 1024,
+      "sparse_bytes": 858,
+      "model_best": "sparse_mask+2bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.5
+    },
+    {
+      "bits": 2,
+      "density": 0.75,
+      "dense_kbit_bytes": 1024,
+      "sparse_bytes": 1028,
+      "model_best": "dense_2bit",
+      "empirical_best": "dense",
+      "crossover_density": 0.5
+    },
+    {
+      "bits": 2,
+      "density": 0.9,
+      "dense_kbit_bytes": 1024,
+      "sparse_bytes": 1124,
+      "model_best": "dense_2bit",
+      "empirical_best": "dense",
+      "crossover_density": 0.5
+    },
+    {
+      "bits": 4,
+      "density": 0.02,
+      "dense_kbit_bytes": 2048,
+      "sparse_bytes": 548,
+      "model_best": "sparse_mask+4bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.75
+    },
+    {
+      "bits": 4,
+      "density": 0.1,
+      "dense_kbit_bytes": 2048,
+      "sparse_bytes": 708,
+      "model_best": "sparse_mask+4bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.75
+    },
+    {
+      "bits": 4,
+      "density": 0.25,
+      "dense_kbit_bytes": 2048,
+      "sparse_bytes": 996,
+      "model_best": "sparse_mask+4bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.75
+    },
+    {
+      "bits": 4,
+      "density": 0.5,
+      "dense_kbit_bytes": 2048,
+      "sparse_bytes": 1476,
+      "model_best": "sparse_mask+4bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.75
+    },
+    {
+      "bits": 4,
+      "density": 0.75,
+      "dense_kbit_bytes": 2048,
+      "sparse_bytes": 1960,
+      "model_best": "sparse_mask+4bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.75
+    },
+    {
+      "bits": 4,
+      "density": 0.9,
+      "dense_kbit_bytes": 2048,
+      "sparse_bytes": 2212,
+      "model_best": "dense_4bit",
+      "empirical_best": "dense",
+      "crossover_density": 0.75
+    },
+    {
+      "bits": 8,
+      "density": 0.02,
+      "dense_kbit_bytes": 4096,
+      "sparse_bytes": 600,
+      "model_best": "sparse_mask+8bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.875
+    },
+    {
+      "bits": 8,
+      "density": 0.1,
+      "dense_kbit_bytes": 4096,
+      "sparse_bytes": 912,
+      "model_best": "sparse_mask+8bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.875
+    },
+    {
+      "bits": 8,
+      "density": 0.25,
+      "dense_kbit_bytes": 4096,
+      "sparse_bytes": 1520,
+      "model_best": "sparse_mask+8bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.875
+    },
+    {
+      "bits": 8,
+      "density": 0.5,
+      "dense_kbit_bytes": 4096,
+      "sparse_bytes": 2544,
+      "model_best": "sparse_mask+8bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.875
+    },
+    {
+      "bits": 8,
+      "density": 0.75,
+      "dense_kbit_bytes": 4096,
+      "sparse_bytes": 3584,
+      "model_best": "sparse_mask+8bit",
+      "empirical_best": "sparse",
+      "crossover_density": 0.875
+    },
+    {
+      "bits": 8,
+      "density": 0.9,
+      "dense_kbit_bytes": 4096,
+      "sparse_bytes": 4184,
+      "model_best": "dense_8bit",
+      "empirical_best": "dense",
+      "crossover_density": 0.875
+    }
+  ],
+  "bptt_residual": {
+    "shape_TBH": [
+      8,
+      8,
+      24
+    ],
+    "event_density": 0.9212239980697632,
+    "grid_bits": 6,
+    "fp32_residual_bytes": 6144,
+    "dense_kbit_bytes": 1152,
+    "sparse_bytes": 1254,
+    "dense_vs_fp32_x": 5.333333333333333,
+    "sparse_vs_fp32_x": 4.899521531100478
+  }
+}

--- a/src/spyx/experimental/__init__.py
+++ b/src/spyx/experimental/__init__.py
@@ -29,8 +29,12 @@ Contents:
   spiking sibling ``SpikingSlotMemory``, after Raven (Afzal, Bick, Xing, Cevher,
   Gu 2026). Plus ``SlotRouter`` and the ``make_recall_batch`` MQAR generator.
 - :mod:`spyx.experimental.compress` — bit-packed activation storage for
-  memory-efficient BPTT (``packed_spike_dense``, ``pack_spikes``,
-  ``unpack_spikes``).
+  memory-efficient BPTT. Binary spikes (``packed_spike_dense``, ``pack_spikes``,
+  ``unpack_spikes``) plus the *quantized/sparse* generalisation: k-bit bit-plane
+  packing (``pack_nbit``/``unpack_nbit``), a k-bit BPTT dense
+  (``packed_quant_dense``), sparse occupancy-mask + code packing
+  (``sparse_quant_pack``/``sparse_quant_unpack``), and a ``packing_footprint``
+  byte-count / crossover helper.
 - :mod:`spyx.experimental.onnx` — export a spiking model to ONNX: the
   per-timestep step ``(x_t, state) -> (out, new_state)`` (flat tensor I/O), or,
   when a sequence length is given, the whole ``spyx.nn.run`` temporal loop as a
@@ -67,7 +71,17 @@ from . import (
     stochastic,
     zoo,
 )
-from .compress import pack_spikes, packed_spike_dense, unpack_spikes
+from .compress import (
+    pack_nbit,
+    pack_spikes,
+    packed_quant_dense,
+    packed_spike_dense,
+    packing_footprint,
+    sparse_quant_pack,
+    sparse_quant_unpack,
+    unpack_nbit,
+    unpack_spikes,
+)
 from .hybrid import (
     es_gradient,
     hybrid_diagnostics,
@@ -115,6 +129,12 @@ __all__ = [
     "packed_spike_dense",
     "pack_spikes",
     "unpack_spikes",
+    "pack_nbit",
+    "unpack_nbit",
+    "packed_quant_dense",
+    "sparse_quant_pack",
+    "sparse_quant_unpack",
+    "packing_footprint",
     "SPSN",
     "StochasticAssociativeLIF",
     "StochasticAssociativeCuBaLIF",

--- a/src/spyx/experimental/compress.py
+++ b/src/spyx/experimental/compress.py
@@ -17,6 +17,14 @@ unpack-recompute for a large cut in the dominant activation residual.
 Correctness relies on the input being exactly binary (values in ``{0, 1}``);
 :func:`packed_spike_dense` is only valid for spike tensors, not arbitrary
 floats.
+
+The lower half of this module generalises the same idea to **quantized** and
+**sparse** activations (graded sigma-delta events, ternary, int-N): pack at
+``bits`` bits with :func:`pack_nbit` (bit-plane packing), use
+:func:`packed_quant_dense` for the k-bit BPTT residual, or — when the tensor is
+also sparse — store a 1-bit occupancy mask plus only the nonzero codes with
+:func:`sparse_quant_pack`. :func:`packing_footprint` gives the byte counts and
+the density crossover between the dense-k-bit and sparse schemes.
 """
 
 import jax
@@ -26,6 +34,12 @@ __all__ = [
     "pack_spikes",
     "unpack_spikes",
     "packed_spike_dense",
+    "pack_nbit",
+    "unpack_nbit",
+    "packed_quant_dense",
+    "sparse_quant_pack",
+    "sparse_quant_unpack",
+    "packing_footprint",
 ]
 
 
@@ -112,3 +126,145 @@ def _packed_spike_dense_bwd(residual, g):
 
 
 packed_spike_dense.defvjp(_packed_spike_dense_fwd, _packed_spike_dense_bwd)
+
+
+# --------------------------------------------------------------------------- #
+# Generalization: packing *quantized* (k-bit) and *sparse* activations.
+#
+# Binary spikes are the k=1, no-sparsity-exploited special case. Two axes:
+#   * quantization -> pack each value at `bits` bits (not 1). `pack_nbit` stores
+#     `bits/8` bytes/element vs 4 for fp32 -> a 32/bits x cut. Jit-friendly, and
+#     `packed_quant_dense` is the k-bit `packed_spike_dense` for BPTT residuals.
+#   * sparsity     -> store only the nonzeros: a 1-bit occupancy mask + the
+#     nonzero values' k-bit codes. `sparse_quant_pack` costs
+#     ceil(N/8) + ceil(nnz*bits/8) bytes, which beats dense k-bit packing when the
+#     density nnz/N < (bits-1)/bits (e.g. < 3/4 at 4-bit). Graded sigma-delta / high-
+#     sparsity spiking sit far inside that regime.
+# --------------------------------------------------------------------------- #
+
+
+def pack_nbit(codes, bits, axis=-1):
+    """Bit-pack an integer-code tensor (values in ``[0, 2**bits)``) along ``axis``.
+
+    Generalises :func:`pack_spikes` (``bits=1``) to any width by packing each of the
+    ``bits`` bit-planes with :func:`jax.numpy.packbits` and stacking them on a new
+    leading axis. Storage is ``bits/8`` bytes/element (a ``32/bits`` x cut vs fp32).
+    """
+    codes = codes.astype(jnp.uint32)
+    planes = [
+        jnp.packbits(((codes >> b) & 1).astype(jnp.uint8), axis=axis)
+        for b in range(bits)
+    ]
+    return jnp.stack(planes, axis=0)
+
+
+def unpack_nbit(packed, bits, length, axis=-1):
+    """Invert :func:`pack_nbit`, recovering integer codes ``length`` long on ``axis``."""
+    out = None
+    for b in range(bits):
+        plane = jnp.unpackbits(packed[b], axis=axis, count=length).astype(jnp.uint32)
+        shifted = plane << jnp.uint32(b)
+        out = shifted if out is None else (out | shifted)
+    return out
+
+
+@jax.custom_vjp
+def packed_quant_dense(acts, weight, bits, step):
+    """``acts @ weight`` with a **k-bit-packed** backward residual.
+
+    The k-bit generalisation of :func:`packed_spike_dense`: for activations that are
+    grid-quantised (symmetric uniform grid of spacing ``step`` representable in ``bits``
+    signed levels -- e.g. graded sigma-delta events, ternary, int-N), the backward saves
+    the ``bits``-bit codes instead of the fp residual (a ``32/bits`` x cut), unpacking
+    them to reform ``dW = acts^T @ g`` exactly. First-order VJP only; exact iff ``acts``
+    lie on the grid ``{(c - 2**(bits-1)) * step}``.
+    """
+    return _dense(acts, weight)
+
+
+def _pqd_fwd(acts, weight, bits, step):
+    out = _dense(acts, weight)
+    offset = 1 << (bits - 1)
+    codes = jnp.clip(
+        jnp.round(acts / step).astype(jnp.int32) + offset, 0, (1 << bits) - 1
+    )
+    packed = pack_nbit(codes.astype(jnp.uint32), bits, axis=-1)
+    return out, (packed, acts.shape, weight, bits, step)
+
+
+def _pqd_bwd(residual, g):
+    packed, acts_shape, weight, bits, step = residual
+    in_features = acts_shape[-1]
+    offset = 1 << (bits - 1)
+    codes = unpack_nbit(packed, bits, in_features, axis=-1)
+    acts = (codes.astype(g.dtype) - offset) * step
+    flat_acts = acts.reshape(-1, in_features)
+    flat_g = g.reshape(-1, weight.shape[-1])
+    dweight = flat_acts.T @ flat_g
+    dacts = (flat_g @ weight.T).reshape(acts_shape)
+    # gradients w.r.t. the non-differentiable bits / step are zero.
+    return dacts, dweight, None, None
+
+
+packed_quant_dense.defvjp(_pqd_fwd, _pqd_bwd)
+
+
+def sparse_quant_pack(x, bits, step):
+    """Pack a **sparse + quantised** tensor as ``(mask_packed, codes_packed, meta)``.
+
+    A 1-bit occupancy mask (``packbits`` of ``x != 0``) plus the nonzero values' ``bits``-bit
+    codes (:func:`pack_nbit`). Footprint ``ceil(N/8) + ceil(nnz*bits/8)`` bytes, which beats
+    dense k-bit packing when density ``nnz/N < (bits-1)/bits``. Exact for grid-quantised ``x``.
+    Eager (uses the dynamic nonzero count) -- for storage / event transmission, not a jit loop.
+    """
+    flat = x.reshape(-1)
+    mask = flat != 0
+    mask_packed = jnp.packbits(mask.astype(jnp.uint8))
+    nz = flat[mask]
+    offset = 1 << (bits - 1)
+    codes = jnp.clip(
+        jnp.round(nz / step).astype(jnp.int32) + offset, 0, (1 << bits) - 1
+    )
+    codes_packed = pack_nbit(codes.astype(jnp.uint32), bits, axis=-1)
+    meta = {
+        "shape": tuple(x.shape),
+        "bits": bits,
+        "step": float(step),
+        "nnz": int(nz.size),
+    }
+    return mask_packed, codes_packed, meta
+
+
+def sparse_quant_unpack(mask_packed, codes_packed, meta):
+    """Invert :func:`sparse_quant_pack` to the dense grid-quantised tensor."""
+    shape, bits, step, nnz = meta["shape"], meta["bits"], meta["step"], meta["nnz"]
+    n = 1
+    for d in shape:
+        n *= d
+    mask = jnp.unpackbits(mask_packed, count=n).astype(bool)
+    codes = unpack_nbit(codes_packed, bits, nnz, axis=-1)
+    offset = 1 << (bits - 1)
+    vals = (codes.astype(jnp.float32) - offset) * step
+    idx = jnp.nonzero(mask, size=nnz)[0]
+    return jnp.zeros(n, jnp.float32).at[idx].set(vals).reshape(shape)
+
+
+def packing_footprint(n_elements, bits, density):
+    """Bytes to store ``n_elements`` grid-quantised activations at ``bits`` bits and the
+    given nonzero ``density``, under three schemes, plus which one wins.
+
+    Schemes: ``fp32`` (4 B/elem), ``dense_kbit`` (``N*bits/8``), and
+    ``sparse`` (mask ``N/8`` + nonzero codes ``nnz*bits/8``). The sparse scheme wins below
+    the ``(bits-1)/bits`` density crossover.
+    """
+    import math
+
+    nnz = round(density * n_elements)
+    schemes = {
+        "fp32": 4 * n_elements,
+        "dense_%dbit" % bits: math.ceil(n_elements * bits / 8),
+        "sparse_mask+%dbit" % bits: math.ceil(n_elements / 8)
+        + math.ceil(nnz * bits / 8),
+    }
+    best = min(schemes, key=schemes.get)
+    return {**schemes, "best": best, "crossover_density": (bits - 1) / bits}

--- a/src/spyx/experimental/compress.py
+++ b/src/spyx/experimental/compress.py
@@ -266,5 +266,5 @@ def packing_footprint(n_elements, bits, density):
         "sparse_mask+%dbit" % bits: math.ceil(n_elements / 8)
         + math.ceil(nnz * bits / 8),
     }
-    best = min(schemes, key=schemes.get)
+    best = min(schemes, key=lambda name: schemes[name])
     return {**schemes, "best": best, "crossover_density": (bits - 1) / bits}

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -7,7 +7,17 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from spyx.experimental.compress import pack_spikes, packed_spike_dense, unpack_spikes
+from spyx.experimental.compress import (
+    pack_nbit,
+    pack_spikes,
+    packed_quant_dense,
+    packed_spike_dense,
+    packing_footprint,
+    sparse_quant_pack,
+    sparse_quant_unpack,
+    unpack_nbit,
+    unpack_spikes,
+)
 
 
 def _naive_dense(spikes, weight):
@@ -81,3 +91,85 @@ def test_saved_residual_is_uint8_and_compact():
     assert packed.size == expected_bytes
     # For n=20 -> 3 bytes vs 20 floats: strictly smaller element count.
     assert packed.size < spikes.size
+
+
+# --------------------------------------------------------------------------- #
+# k-bit and sparse packing (quantized activations)
+# --------------------------------------------------------------------------- #
+
+
+def _grid_codes(key, shape, bits):
+    """Random integer codes in ``[0, 2**bits)`` as uint32."""
+    return jax.random.randint(key, shape, 0, 1 << bits).astype(jnp.uint32)
+
+
+@pytest.mark.parametrize("bits", [1, 2, 3, 4, 8])
+@pytest.mark.parametrize("length", [8, 5, 13, 32])
+def test_pack_nbit_roundtrip(bits, length):
+    """pack_nbit -> unpack_nbit is lossless for any width and (padded) length."""
+    codes = _grid_codes(jax.random.PRNGKey(bits * 100 + length), (3, 7, length), bits)
+    packed = pack_nbit(codes, bits, axis=-1)
+    assert packed.dtype == jnp.uint8
+    assert packed.shape[0] == bits  # one bit-plane per bit
+    restored = unpack_nbit(packed, bits, length, axis=-1)
+    np.testing.assert_array_equal(np.asarray(restored), np.asarray(codes))
+
+
+def test_pack_nbit_generalizes_pack_spikes():
+    """bits=1 pack_nbit reproduces pack_spikes (up to the leading plane axis)."""
+    x = (jax.random.uniform(jax.random.PRNGKey(0), (4, 16)) < 0.5).astype(jnp.uint32)
+    np.testing.assert_array_equal(
+        np.asarray(pack_nbit(x, 1, axis=-1)[0]), np.asarray(pack_spikes(x, axis=-1))
+    )
+
+
+def test_packed_quant_dense_matches_naive_on_grid():
+    """Forward + both grads equal the naive dense for grid-quantized activations."""
+    bits, step = 4, 0.25
+    offset = 1 << (bits - 1)
+    codes = jax.random.randint(jax.random.PRNGKey(1), (10, 16), 0, 1 << bits)
+    acts = (codes - offset).astype(jnp.float32) * step  # exactly on the grid
+    weight = jax.random.normal(jax.random.PRNGKey(2), (16, 6))
+    target = jax.random.normal(jax.random.PRNGKey(3), (10, 6))
+
+    def loss_packed(a, w):
+        return jnp.sum((packed_quant_dense(a, w, bits, step) - target) ** 2)
+
+    def loss_naive(a, w):
+        return jnp.sum((_naive_dense(a, w) - target) ** 2)
+
+    assert jnp.allclose(
+        packed_quant_dense(acts, weight, bits, step),
+        _naive_dense(acts, weight),
+        atol=1e-5,
+    )
+    gp = jax.grad(loss_packed, argnums=(0, 1))(acts, weight)
+    gn = jax.grad(loss_naive, argnums=(0, 1))(acts, weight)
+    assert jnp.allclose(gp[0], gn[0], atol=1e-4)  # dacts
+    assert jnp.allclose(gp[1], gn[1], atol=1e-4)  # dweight
+
+
+def test_sparse_quant_pack_roundtrip_and_footprint():
+    """Occupancy-mask + codes packing is exact and beats dense k-bit below crossover."""
+    bits, step = 4, 0.25
+    key = jax.random.PRNGKey(4)
+    dense_codes = jax.random.randint(key, (4, 20), -3, 4).astype(jnp.float32) * step
+    keep = jax.random.uniform(jax.random.PRNGKey(5), (4, 20)) < 0.2  # ~20% density
+    x = jnp.where(keep, dense_codes, 0.0)
+
+    mask_packed, codes_packed, meta = sparse_quant_pack(x, bits, step)
+    restored = sparse_quant_unpack(mask_packed, codes_packed, meta)
+    np.testing.assert_array_equal(np.asarray(restored), np.asarray(x))
+    assert meta["nnz"] == int(jnp.sum(x != 0))
+
+
+def test_packing_footprint_crossover():
+    """Sparse wins below (bits-1)/bits density; dense k-bit wins above it."""
+    n, bits = 1_000_000, 4
+    low = packing_footprint(n, bits, 0.1)
+    high = packing_footprint(n, bits, 0.9)
+    assert low["crossover_density"] == (bits - 1) / bits
+    assert low["best"].startswith("sparse")
+    assert high["best"].startswith("dense")
+    # fp32 is never the winner for a 4-bit grid.
+    assert low["best"] != "fp32" and high["best"] != "fp32"


### PR DESCRIPTION
## What

Generalises the binary-spike bit-packing in `spyx.experimental.compress`
(`packed_spike_dense`) to **quantized** and **sparse** activations — graded
sigma-delta events, ternary, int-N — along two independent axes:

- **Quantization** — `pack_nbit`/`unpack_nbit` (bit-plane packing at *k* bits) and
  `packed_quant_dense`, the *k*-bit BPTT residual: a `32/bits×` cut of the dominant
  activation memory, with forward **and both gradients exact** for grid-quantized
  activations.
- **Sparsity** — `sparse_quant_pack`/`sparse_quant_unpack`: a 1-bit occupancy mask
  plus only the nonzero *k*-bit codes. Costs `ceil(N/8) + ceil(nnz·bits/8)` bytes,
  which beats dense *k*-bit packing **below a density of `(bits-1)/bits`**.
- `packing_footprint` — analytic byte counts for fp32 / dense-*k*-bit / sparse and
  the crossover.

## Evidence

`research/new/activation_packing/` (self-contained; byte counts are hardware-independent):

- **Exact:** roundtrip bit-exact for every width; `packed_quant_dense` grads match
  the naive dense to fp32 rounding.
- **Crossover confirmed 18/18** across `bits ∈ {2,4,8}` × `density ∈ {0.02…0.9}` —
  empirical packed `nbytes` agree with the analytic model at every point.
- **5.3× vs fp32** BPTT residual on a real graded `SigmaDelta` activation (dense,
  random input → dense *k*-bit wins, exactly as the crossover predicts; the sparse
  win lands on *redundant* input where sigma-delta event density collapses to ~3%).

## Honest framing

A **memory / transmission** win (BPTT residual, storage, event transmission,
neuromorphic targets), **not** a compute win — on a dense GPU the pack/unpack is
extra work and nothing is sparsity-skipped. Exactness requires on-grid inputs;
`sparse_quant_pack` is eager (dynamic nnz); first-order VJP only.

## Tests / docs

- `tests/test_compress.py`: roundtrip exactness (5 widths), `pack_nbit` ⊃ `pack_spikes`,
  `packed_quant_dense` gradient equivalence, footprint crossover. Full suite green
  (288 passed).
- `research/FINDINGS.md` row (✅, experimental-ready); substrate explanation doc updated;
  `docs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)