### PR TITLE
TTT fast-weight layer + three-factor plasticity + feedback alignment

### DIFF
--- a/docs/reference/experimental.md
+++ b/docs/reference/experimental.md
@@ -29,6 +29,9 @@ of the library.
 | [`spyx.experimental.stochastic`](#spyxexperimentalstochastic) | Module | Stochastic (Bernoulli-spiking) and parallelizable prototypes: `SPSN`, `StochasticAssociative{LIF,CuBaLIF}`, and the `sigmoid_bernoulli` activations. |
 | [`spyx.experimental.hybrid`](#spyxexperimentalhybrid) | Module | The 0+1 hybrid trainer: surrogate gradient + antithetic-NES correction projected orthogonal to the surrogate (`hybrid_gradient`, `make_hybrid_train_step`, `es_gradient`, `hybrid_diagnostics`), plus the surrogate-steered **Self-Guided ES** variant (`sges_gradient`, `make_sges_hybrid_train_step`) — the surrogate direction is SGES's guiding subspace, so ES is spent on the orthogonal complement at several-fold lower variance. |
 | [`spyx.experimental.matfree`](#spyxexperimentalmatfree) | Module | Matmul-free linear primitives — ternary (BitNet: `TernaryLinear`, `TernaryMLP`) and shift-add (DeepShift: `ShiftAddLinear`) layers that replace dense multiplies with accumulations / bit-shifts, plus `MatMulFreeBlock`, `MLGRU`, `RMSNorm`, and the `ternary_weights` / `power_of_two_weights` / `activation_quant` STE helpers. The native train-from-scratch counterpart to the post-training [`spyx.quant.bitnet_ternary_rules`](quant.md) path. |
+| [`spyx.experimental.ttt`](#spyxexperimentalttt) | Module | Test-time-training / fast-weight sequence layer (`TTTFastWeight`): the hidden *state is a weight matrix* updated online per token by a hebb rule (scalar transition → `.parallel` associative scan) or error-correcting delta rule (matrix transition → sequential `spyx.nn.run`). |
+| [`spyx.experimental.local_learning`](#spyxexperimentallocal_learning) | Module | Local online three-factor (e-prop / OTTT-style) plasticity (`ThreeFactorLIF`): a per-synapse eligibility trace + modulator-gated update applied *during* the forward pass (no BPTT), with meta-learnable coefficients an outer SGD/ES loop can tune. |
+| [`spyx.experimental.feedback_alignment`](#spyxexperimentalfeedback_alignment) | Module | Backprop-free training via fixed *random* feedback: Feedback Alignment (`FALinear`, `fa_dense`) and Direct Feedback Alignment (`dfa_inject`, `dfa_gradient`), composing with surrogate spiking neurons through `jax.custom_vjp`. |
 | [`spyx.experimental.zoo`](#spyxexperimentalzoo) | Package | Runnable reference recipes keyed by application (control / classification / language) and tagged by training method × architecture (`REGISTRY`, `list_recipes`, `get`). |
 | [`spyx.experimental.onnx`](#spyxexperimentalonnx) | Module | Export a spiking model to ONNX — per-timestep step, or the whole `spyx.nn.run` loop as a native ONNX `Scan`/`Loop`. Conversion deps imported lazily. |
 
@@ -85,6 +88,18 @@ estimators. See [Training methods](../explanation/training-methods.md) for where
 this sits relative to post-training quantization ([`spyx.quant`](quant.md)).
 
 ::: spyx.experimental.matfree
+
+## spyx.experimental.ttt
+
+::: spyx.experimental.ttt
+
+## spyx.experimental.local_learning
+
+::: spyx.experimental.local_learning
+
+## spyx.experimental.feedback_alignment
+
+::: spyx.experimental.feedback_alignment
 
 ## spyx.experimental.onnx
 

--- a/research/FINDINGS.md
+++ b/research/FINDINGS.md
@@ -42,6 +42,7 @@ FP4×SNN gap and its neighbours).
 
 | Study | Claim (short) | Verdict | Status | Landed in / note |
 | --- | --- | --- | --- | --- |
+| [es_meta_plasticity_scout](new/es_meta_plasticity_scout/) | ES-meta-learned local plasticity for spiking nets is an unclaimed gap | ❌ | new | **CLAIMED** (3/3 skeptics): Confavreux 2025 (CMA-ES) + Jordan 2021 (genetic prog) both do ES × local-plasticity × spiking; only the assoc-scan-parallel framing is residual. Shipped TTT / three-factor / FA-DFA as cited building blocks |
 | [hybrid_evo_surrogate](new/hybrid_evo_surrogate/) | Orthogonal-ES / SGES correction beats surrogate on the hard-spike loss | ➖ | experimental | `spyx.experimental.hybrid` (safe, not a win — needs large-bias regime) |
 | [raven_sparse_memory_recall](new/raven_sparse_memory_recall/) | Routing-slot memory beats a diagonal SSM on recall | ✅ (modest) | experimental | `spyx.experimental.raven` (regime-dependent) |
 | [ssm_to_spiking_transfer](new/ssm_to_spiking_transfer/) | R&F *is* a thresholded S5Diag; transferring SSM dynamics helps spiking | ➖ | new | equivalence exact; S5Diag still beats the spiking variant |

--- a/research/new/es_meta_plasticity_scout/README.md
+++ b/research/new/es_meta_plasticity_scout/README.md
@@ -1,0 +1,66 @@
+# Scout verdict: ES-meta-learned spiking plasticity — **gap is CLAIMED**
+
+## Question
+
+Is "using an **evolutionary/ES outer loop** to meta-learn a **local synaptic
+plasticity / three-factor** rule for **spiking** networks (optionally with the plastic
+update framed as a parallelizable associative-scan)" an *unclaimed* research gap worth
+a novelty claim?
+
+## Method
+
+Multi-agent scout: 5 parallel literature-search angles (evolved plasticity, spiking-evo
+online learning, TTT/fast-weights, e-prop/OTTT, FA/DFA-for-SNN) → 43 direct/adjacent
+prior-art candidates → **3 independent adversarial skeptics** each hunting the closest
+prior art, defaulting to *refuted* when in doubt (the same discipline that killed the
+F1/F2 false gaps and confirmed F3 in [PR #67](../../FINDINGS.md)). Majority rules.
+
+## Verdict — **CLAIMED, 3/3 skeptics, high confidence**
+
+The three core ingredients — (1) evolutionary/gradient-free outer loop, (2) local
+plasticity / three-factor inner rule, (3) spiking neurons — are already **jointly**
+claimed:
+
+| Prior art | What it does |
+| --- | --- |
+| **Confavreux, Agnes, Zenke, Lillicrap, Vogels et al.**, *Balancing complexity, performance and plausibility to meta-learn plasticity rules in recurrent spiking networks*, **PLOS Comput. Biol. 2025** ([article](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1012910), bioRxiv 2024.06.17.599260) | **CMA-ES** (a literal evolution strategy) as the outer loop meta-learns *local* co-active plasticity rules (polynomial → MLP parameterizations) inside *recurrent spiking* E/I networks. |
+| **Jordan, Schmidt, Senn, Petrovici**, *Evolving to learn: discovering interpretable plasticity rules for spiking networks*, **eLife 2021** ([article](https://elifesciences.org/articles/66273), arXiv:2005.14149); RL variant arXiv:2202.12322 | **Cartesian genetic programming** (evolutionary outer loop) discovers interpretable *local three-factor* spiking plasticity rules across reward-, error-, and correlation-driven regimes. |
+
+Per the ruling criterion, ES × local-plasticity × spiking being co-present — even absent
+parallelization — makes the gap claimed. **We do not claim novelty here.**
+
+## The one thin residual (not worth a novelty claim on its own)
+
+The *only* differentiator the target framing adds is expressing the evolved local
+delta/three-factor update as a **parallelizable associative-scan (affine-recurrence)**
+inner loop. That machinery exists but only *separately and non-spiking*: Yang et al.,
+*Parallelizing Linear Transformers with the Delta Rule over Sequence Length*, NeurIPS
+2024 ([arXiv:2406.06484](https://arxiv.org/abs/2406.06484)), which is gradient-trained.
+This is an **implementation/efficiency** delta, not a new meta-learning capability — an
+engineering nicety, not a paper.
+
+## What we built anyway (library building blocks, cited to their sources)
+
+The scout was paired with a build: three **implementations of published methods** now
+live in `spyx.experimental` — useful regardless of the (negative) novelty finding, and
+they make the "associative-scan-parallel evolved plasticity" residual cheap to try:
+
+- [`ttt.TTTFastWeight`](../../../src/spyx/experimental/ttt.py) — fast-weight / TTT layer
+  (Sun 2024 arXiv:2407.04620; Schlag 2021 arXiv:2102.11174). Its **hebb** rule is a
+  matrix-valued `PSU_LIF` (scalar transition → `associative_scan`); its **delta** rule is
+  sequential-only here (matrix transition; points to DeltaNet).
+- [`local_learning.ThreeFactorLIF`](../../../src/spyx/experimental/local_learning.py) —
+  online e-prop/OTTT three-factor plasticity (Bellec 2020; Xiao 2022). Coefficients are
+  the only `nnx.Param`s, so `spyx.experimental.hybrid`/`evolve` (ES) meta-learn the rule —
+  i.e. this *is* the substrate of the (already-claimed) idea, provided as a clean tool.
+- [`feedback_alignment`](../../../src/spyx/experimental/feedback_alignment.py) — FA
+  (Lillicrap 2016) and DFA (Nøkland 2016) backprop-free training via random feedback.
+
+## Reproducibility
+
+- **Scout:** 11-agent workflow (5 scout + 3 verify + 3 design), web-search-grounded,
+  honesty-constrained; all citations verified with real titles/URLs.
+- **Correctness of the builds:** `tests/test_ttt.py`, `tests/test_local_learning.py`,
+  `tests/test_feedback_alignment.py` (parallel==sequential, FA↔BP alignment, DFA >0.6 acc,
+  trace decay, meta-grad/ES reachability).
+- **Date run:** 2026-07-06.

--- a/src/spyx/experimental/__init__.py
+++ b/src/spyx/experimental/__init__.py
@@ -43,6 +43,22 @@ Contents:
 - :mod:`spyx.experimental.stochastic` — stochastic (Bernoulli-spiking) and
   parallelizable prototypes: ``SPSN``, ``StochasticAssociativeLIF``,
   ``StochasticAssociativeCuBaLIF`` and the ``sigmoid_bernoulli`` activations.
+- :class:`~spyx.experimental.TTTFastWeight` — test-time-training / fast-weight
+  sequence layer whose hidden *state is a weight matrix* updated online per token
+  by a hebb (``rule="hebb"``, scalar transition → ``.parallel`` associative scan,
+  a matrix-valued ``PSU_LIF``) or error-correcting delta rule (``rule="delta"``,
+  matrix transition → sequential ``spyx.nn.run``; chunked-DeltaNet for parallel).
+- :mod:`spyx.experimental.local_learning` — local online three-factor
+  (e-prop / OTTT-style) plasticity: :class:`ThreeFactorLIF`, a plastic-synapse
+  LIF that maintains a per-synapse eligibility trace and applies a
+  modulator-gated ``ΔW = eta * <mod * trace>`` *during* the forward-through-time
+  pass (no BPTT), with meta-learnable coefficients an outer SGD/ES loop can tune.
+  It is the neuromorphic, spiking sibling of the ``TTTFastWeight`` delta rule.
+- :mod:`spyx.experimental.feedback_alignment` — backprop-free training via fixed
+  *random* feedback (weight-transport-free): :class:`FALinear` / ``fa_dense``
+  (layer-local Feedback Alignment, Lillicrap 2016) and ``dfa_inject`` /
+  ``dfa_gradient`` (Direct Feedback Alignment, Nøkland 2016), composing with
+  surrogate spiking neurons and ``spyx.nn.run`` via ``jax.custom_vjp``.
 - :mod:`spyx.experimental.hybrid` — the 0+1 hybrid trainer: a surrogate
   gradient corrected by an antithetic-NES estimate of the true (hard-spike)
   loss, projected orthogonal to the surrogate (``hybrid_gradient``,
@@ -61,7 +77,9 @@ from ..phasor import ResonateFire
 from . import (
     compress,
     evolve,
+    feedback_alignment,
     hybrid,
+    local_learning,
     matfree,
     onnx,
     parallel_reset,
@@ -69,6 +87,7 @@ from . import (
     rf_ssm,
     sigma_delta,
     stochastic,
+    ttt,
     zoo,
 )
 from .compress import (
@@ -82,6 +101,13 @@ from .compress import (
     unpack_nbit,
     unpack_spikes,
 )
+from .feedback_alignment import (
+    FALinear,
+    Feedback,
+    dfa_gradient,
+    dfa_inject,
+    fa_dense,
+)
 from .hybrid import (
     es_gradient,
     hybrid_diagnostics,
@@ -90,6 +116,7 @@ from .hybrid import (
     make_sges_hybrid_train_step,
     sges_gradient,
 )
+from .local_learning import ThreeFactorLIF, surrogate_deriv
 from .parallel_reset import ParallelResetLIF
 from .raven import RavenRSM, SlotRouter, SpikingSlotMemory, make_recall_batch
 from .rf_ssm import RFSSM, ResonateFireSSM
@@ -101,11 +128,14 @@ from .stochastic import (
     refractory_sigmoid_bernoulli,
     sigmoid_bernoulli,
 )
+from .ttt import TTTFastWeight
 
 __all__ = [
     "compress",
     "evolve",
+    "feedback_alignment",
     "hybrid",
+    "local_learning",
     "matfree",
     "onnx",
     "parallel_reset",
@@ -113,12 +143,21 @@ __all__ = [
     "rf_ssm",
     "sigma_delta",
     "stochastic",
+    "ttt",
     "zoo",
     "ParallelResetLIF",
     "RFSSM",
     "ResonateFireSSM",
     "SigmaDelta",
     "graded_quant",
+    "ThreeFactorLIF",
+    "surrogate_deriv",
+    "TTTFastWeight",
+    "Feedback",
+    "FALinear",
+    "fa_dense",
+    "dfa_inject",
+    "dfa_gradient",
     "PSU_LIF",
     "AssociativeLIF",
     "ResonateFire",

--- a/src/spyx/experimental/feedback_alignment.py
+++ b/src/spyx/experimental/feedback_alignment.py
@@ -1,0 +1,268 @@
+r"""Backprop-free training via random feedback: Feedback Alignment / Direct FA.
+
+Backpropagation forms the hidden-layer error by multiplying the downstream error
+by the *transpose of the forward weights*, ``W^T``. That exact ``W^T`` -- the
+"weight-transport problem" -- is what makes BP biologically implausible and
+awkward on neuromorphic hardware. **Feedback Alignment** replaces ``W^T`` with a
+*fixed random* matrix ``B``; remarkably, the forward weights then rotate during
+training until they partially align with ``B``, so the random pseudo-gradient
+acquires a positive projection on the true gradient and the network learns.
+
+Two variants are provided, both as exact-forward / random-backward ops built with
+:func:`jax.custom_vjp`, so the surrogate spike gradient (:mod:`spyx.axn`) still
+handles the neuron nonlinearity and everything composes with :func:`spyx.nn.run`:
+
+* **Feedback Alignment (FA)** -- *layer-local*. Each :class:`FALinear` keeps its
+  own fixed random ``B`` (the shape of ``W^T``) and, in the backward pass, sends
+  ``g @ B`` to the previous layer instead of ``g @ W^T``. The weight update
+  ``dW = x^T g`` is unchanged. Because it is a drop-in stateless layer, it slots
+  straight into :class:`spyx.nn.Sequential` and is differentiated by a plain
+  ``jax.grad`` / :func:`spyx.nn.run` -- the ``custom_vjp`` silently swaps in the
+  random feedback everywhere, including through the BPTT scan.
+
+* **Direct Feedback Alignment (DFA)** -- *global*. The output error ``e`` is
+  projected **directly** to every hidden layer through a fixed random ``B_l``
+  (shape ``(n_out, hidden_l)``), skipping the layer-by-layer chain entirely.
+  Implemented with the :func:`dfa_inject` identity op, whose backward discards
+  the true downstream cotangent and substitutes ``e @ B_l`` at each hidden
+  neuron's output; ordinary autodiff then carries that through the surrogate
+  spike (applying ``f'``) and the preceding matmul to form the DFA weight update.
+  :func:`dfa_gradient` orchestrates this over a feedforward
+  :class:`spyx.nn.Sequential` and returns grads that drop into
+  ``optimizer.update(model, grads)``.
+
+References (verified):
+
+* Lillicrap, Cownden, Tweed & Akerman, *Random synaptic feedback weights support
+  error backpropagation for deep learning*, Nature Communications 7:13276 (2016),
+  `<https://www.nature.com/articles/ncomms13276>`_.
+* Nøkland, *Direct Feedback Alignment Provides Learning in Deep Neural Networks*,
+  NeurIPS 2016, `arXiv:1609.01596 <https://arxiv.org/abs/1609.01596>`_.
+* Han & Yoo et al., *Spike-Train Level Direct Feedback Alignment*, Frontiers in
+  Neuroscience 14:143 (2020),
+  `<https://www.frontiersin.org/articles/10.3389/fnins.2020.00143/full>`_ -- DFA
+  applied to spiking networks / on-chip training.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+__all__ = [
+    "Feedback",
+    "fa_dense",
+    "FALinear",
+    "dfa_inject",
+    "dfa_gradient",
+]
+
+
+class Feedback(nnx.Variable):
+    """A fixed random feedback matrix -- state that is *never* trained.
+
+    Marking feedback matrices with their own ``nnx.Variable`` subclass keeps them
+    out of ``nnx.split(model, nnx.Param, ...)`` and out of
+    ``nnx.Optimizer(model, tx, wrt=nnx.Param)``, so they stay frozen at their
+    random init while the ``nnx.Param`` weights learn.
+    """
+
+
+def _dense(x: jax.Array, weight: jax.Array) -> jax.Array:
+    """``x @ weight`` over the trailing feature axis, preserving leading dims."""
+    in_features = x.shape[-1]
+    flat = x.reshape(-1, in_features)
+    out = flat @ weight
+    return out.reshape(*x.shape[:-1], weight.shape[-1])
+
+
+@jax.custom_vjp
+def fa_dense(x: jax.Array, weight: jax.Array, feedback: jax.Array) -> jax.Array:
+    """``x @ weight`` with a random-feedback backward pass (Feedback Alignment).
+
+    Forward numerics are exactly ``x @ weight`` (``x`` is ``(..., in)``, ``weight``
+    is ``(in, out)``). The custom VJP leaves the weight gradient exact,
+    ``dW = x^T g``, but replaces the input gradient ``g @ weight^T`` with
+    ``g @ feedback``, where ``feedback`` is the *fixed random* matrix of shape
+    ``(out, in)`` standing in for ``weight^T``. This is the sole difference from a
+    plain dense layer, and it is what makes learning weight-transport-free.
+    """
+    return _dense(x, weight)
+
+
+def _fa_dense_fwd(x, weight, feedback):
+    return _dense(x, weight), (x, weight, feedback)
+
+
+def _fa_dense_bwd(res, g):
+    x, weight, feedback = res
+    in_features = x.shape[-1]
+    out_features = weight.shape[-1]
+    flat_x = x.reshape(-1, in_features)
+    flat_g = g.reshape(-1, out_features)
+    dweight = flat_x.T @ flat_g
+    # Random feedback replaces weight^T: dx = g @ feedback, feedback is (out, in).
+    dx = (flat_g @ feedback).reshape(x.shape)
+    return dx, dweight, jnp.zeros_like(feedback)
+
+
+fa_dense.defvjp(_fa_dense_fwd, _fa_dense_bwd)
+
+
+class FALinear(nnx.Module):
+    r"""Linear layer trained by Feedback Alignment (fixed random backward weights).
+
+    A drop-in replacement for ``nnx.Linear``: the forward pass is the identical
+    affine ``x @ weight + bias``, but the backward pass propagates the error to the
+    previous layer through a *fixed random* ``feedback`` matrix instead of
+    ``weight^T`` (see :func:`fa_dense`). Being stateless, it slots straight into
+    :class:`spyx.nn.Sequential` and is scored over time by :func:`spyx.nn.run`;
+    a plain ``jax.grad`` through the model then yields the FA pseudo-gradient
+    automatically, including through the BPTT scan.
+
+    :in_features: input feature size.
+    :out_features: output feature size.
+    :use_bias: add a learnable bias (default ``True``).
+    :feedback_stddev: standard deviation of the fixed random feedback init.
+    :rngs: ``nnx.Rngs``; ``rngs.params()`` seeds the weight, ``rngs.params()`` the
+        (frozen) feedback.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        use_bias: bool = True,
+        feedback_stddev: float = 0.05,
+        *,
+        rngs: nnx.Rngs,
+    ):
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nnx.Param(
+            nnx.initializers.lecun_normal()(rngs.params(), (in_features, out_features))
+        )
+        self.bias = nnx.Param(jnp.zeros((out_features,))) if use_bias else None
+        # Fixed random feedback standing in for weight^T; shape (out, in).
+        self.feedback = Feedback(
+            nnx.initializers.normal(feedback_stddev)(
+                rngs.params(), (out_features, in_features)
+            )
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        y = fa_dense(x, self.weight[...], self.feedback[...])
+        if self.bias is not None:
+            y = y + self.bias[...]
+        return y
+
+
+@jax.custom_vjp
+def dfa_inject(h: jax.Array, error: jax.Array, feedback: jax.Array) -> jax.Array:
+    """Identity forward; backward injects a direct random projection of ``error``.
+
+    Forward: returns ``h`` unchanged, so wrapping a hidden neuron's spike output in
+    ``dfa_inject`` does not perturb the forward pass at all. Backward: the true
+    downstream cotangent is **discarded** and replaced by ``error @ feedback`` --
+    the Direct-Feedback-Alignment signal, where ``error`` is the global output
+    error ``(batch, n_out)`` and ``feedback`` is the fixed random ``(n_out,
+    hidden)`` matrix. Ordinary autodiff then carries that cotangent back through
+    the surrogate spike (applying ``f'``) and the preceding matmul, so each hidden
+    layer's weight update depends only on the output error, never on the
+    downstream weights. Used by :func:`dfa_gradient`.
+    """
+    del error, feedback
+    return h
+
+
+def _dfa_inject_fwd(h, error, feedback):
+    return h, (error, feedback, jnp.shape(h))
+
+
+def _dfa_inject_bwd(res, g):
+    error, feedback, h_shape = res
+    del g  # the true downstream cotangent is intentionally discarded (DFA)
+    c = jnp.broadcast_to(error @ feedback, h_shape)
+    return c, jnp.zeros_like(error), jnp.zeros_like(feedback)
+
+
+dfa_inject.defvjp(_dfa_inject_fwd, _dfa_inject_bwd)
+
+
+LossFn = Callable[[jax.Array, Any], jax.Array]
+"""``(logits, targets) -> scalar`` loss, differentiable w.r.t. ``logits``."""
+
+
+def dfa_gradient(
+    model: nnx.Module,
+    x: jax.Array,
+    targets: Any,
+    feedbacks: list[jax.Array],
+    *,
+    loss_fn: LossFn,
+) -> nnx.State:
+    r"""Direct-Feedback-Alignment gradients for a feedforward spiking stack.
+
+    ``model`` is a :class:`spyx.nn.Sequential` whose layers alternate stateless
+    transforms (``FALinear`` / ``nnx.Linear`` / ``Flatten``) and surrogate
+    spiking neurons (any layer exposing ``initial_state``), ending in a stateless
+    **readout**. It is evaluated as a single feedforward step (zero initial
+    neuron state), so use a neuron that spikes on its *current* drive, e.g.
+    :class:`spyx.nn.PSU_LIF` (``V = beta V + x`` then spike) rather than one that
+    spikes on the pre-update membrane.
+
+    The update is pure DFA: the output error ``e = d loss / d logits`` is projected
+    to each hidden neuron through its fixed random ``feedbacks[l]`` (shape
+    ``(n_out, hidden_l)``) via :func:`dfa_inject`; the surrogate spike supplies
+    ``f'``; the readout is trained by the true error. Hidden layers are decoupled
+    with :func:`jax.lax.stop_gradient`, so no error crosses between them -- each
+    learns only from the direct projection. Returned grads match ``model``'s
+    ``nnx.Param`` tree and drop into ``optimizer.update(model, grads)``.
+
+    :model: the feedforward ``Sequential`` described above.
+    :x: input batch ``(batch, in)``.
+    :targets: labels forwarded to ``loss_fn``.
+    :feedbacks: one fixed random ``(n_out, hidden_l)`` matrix per hidden neuron.
+    :loss_fn: ``(logits, targets) -> scalar``.
+    :return: an ``nnx.State`` of gradients over the model's ``nnx.Param`` tree.
+    """
+    graphdef, params, rest = nnx.split(model, nnx.Param, ...)
+    batch = x.shape[0]
+
+    def _forward_logits(p):
+        m = nnx.merge(graphdef, p, rest)
+        h = x
+        for layer in m.layers:
+            if hasattr(layer, "initial_state"):
+                h, _ = layer(h, layer.initial_state(batch))
+            else:
+                h = layer(h)
+        return h
+
+    logits = _forward_logits(params)
+    error = jax.lax.stop_gradient(jax.grad(lambda z: loss_fn(z, targets))(logits))
+
+    def objective(p):
+        m = nnx.merge(graphdef, p, rest)
+        h = x
+        k = 0
+        total = jnp.asarray(0.0, logits.dtype)
+        for layer in m.layers:
+            if hasattr(layer, "initial_state"):
+                out, _ = layer(h, layer.initial_state(batch))
+                # Seed cotangent error @ feedbacks[k] at this hidden output.
+                total = total + jnp.sum(dfa_inject(out, error, feedbacks[k]))
+                k = k + 1
+                # Decouple layers: no error flows between hidden blocks (DFA).
+                h = jax.lax.stop_gradient(out)
+            else:
+                h = layer(h)
+        # After the loop ``h`` is the readout logits; train it by the true error.
+        total = total + jnp.sum(h * error)
+        return total
+
+    return jax.grad(objective)(params)

--- a/src/spyx/experimental/feedback_alignment.py
+++ b/src/spyx/experimental/feedback_alignment.py
@@ -236,7 +236,7 @@ def dfa_gradient(
     def _forward_logits(p):
         m = nnx.merge(graphdef, p, rest)
         h = x
-        for layer in m.layers:
+        for layer in m.layers:  # ty: ignore[unresolved-attribute]  # merged Sequential
             if hasattr(layer, "initial_state"):
                 h, _ = layer(h, layer.initial_state(batch))
             else:
@@ -251,7 +251,7 @@ def dfa_gradient(
         h = x
         k = 0
         total = jnp.asarray(0.0, logits.dtype)
-        for layer in m.layers:
+        for layer in m.layers:  # ty: ignore[unresolved-attribute]  # merged Sequential
             if hasattr(layer, "initial_state"):
                 out, _ = layer(h, layer.initial_state(batch))
                 # Seed cotangent error @ feedbacks[k] at this hidden output.

--- a/src/spyx/experimental/local_learning.py
+++ b/src/spyx/experimental/local_learning.py
@@ -1,0 +1,271 @@
+r"""Local online three-factor (e-prop / OTTT-style) plasticity for spiking layers.
+
+Backprop-through-time stores every activation and replays them *backwards* to
+assign credit, which is neither online nor local. **Eligibility propagation**
+(e-prop) replaces the backward replay with a per-synapse **eligibility trace**
+that is maintained *forward in time* and combined with an instantaneous
+top-down **learning signal** (a neuromodulator) to update weights as the
+sequence streams past — a biologically-motivated *three-factor* rule (pre x
+post x modulator). This module implements that rule as a self-contained plastic
+spiking layer whose weights are updated **during** the forward pass, with no
+stored activations and no BPTT.
+
+The three factors
+-----------------
+For a plastic weight ``W[i, j]`` (presynaptic unit ``i`` -> postsynaptic unit
+``j``), each step ``t``:
+
+1. **Presynaptic trace** — a low-pass filter of the input spikes,
+
+   .. math:: \bar p^t_i = \alpha\, \bar p^{t-1}_i + x^t_i .
+
+2. **Postsynaptic pseudo-derivative** — the surrogate slope of the spike
+   nonlinearity at the membrane, computed *in the forward pass* (this is what
+   removes the need for a backward pass):
+
+   .. math:: \psi^t_j = h'(V^t_j - v_\mathrm{th}),
+      \qquad h'(u) = \frac{1}{(1 + k|u|)^2}
+
+   (the SuperSpike slope; the same function ``spyx.axn.superspike(k)`` uses in
+   its backward pass).
+
+3. **Eligibility trace** — a decaying accumulation of the pre x post
+   coincidence, exactly a leaky integrator of the outer product:
+
+   .. math:: e^t_{ij} = \gamma\, e^{t-1}_{ij} + \bar p^t_i\, \psi^t_j .
+
+The weight is then moved by the trace **gated by the modulator** ``m`` (the
+third factor — a reward / error / learning signal delivered per sample, or per
+postsynaptic unit), averaged over the batch:
+
+.. math:: \Delta W^t_{ij} = \eta\; \big\langle m^t\, e^t_{ij}\big\rangle_\mathrm{batch},
+   \qquad W^t = W^{t-1} + \Delta W^t .
+
+This is the online three-factor form shared by e-prop and OTTT: OTTT tracks the
+presynaptic activity :math:`\bar p` and multiplies it by an instantaneous
+gradient/learning signal, which is precisely ``m`` here.
+
+Relation to the TTT delta rule
+------------------------------
+A Test-Time-Training linear layer treats its weights as a fast state and updates
+them by one SGD step of a self-supervised loss; for a linear reconstruction loss
+that step *is* the delta rule, a rank-1 outer-product update
+``W <- W - eta (W k - v) k^T``. That is the **same outer-product skeleton** as
+the eligibility update above: post-factor :math:`\otimes` pre-factor, scaled by a
+rate. e-prop generalises it with (a) an eligibility *memory* ``gamma`` (the TTT
+step keeps no trace, i.e. ``gamma = 0``) and (b) an explicit third factor ``m``
+(TTT folds the modulator into the reconstruction error). Setting ``gamma = 0``
+and letting ``m`` carry the reconstruction error recovers a delta-rule / TTT
+inner step, so this module is the spiking, three-factor generalisation of the
+TTT delta rule.
+
+Meta-learning the rule (the outer loop)
+---------------------------------------
+The rule's coefficients — ``eta`` (rate), ``gamma`` (eligibility decay),
+``alpha`` (presynaptic-filter decay) and ``beta`` (membrane leak) — are plain
+:class:`flax.nnx.Param` scalars, while the plastic weight ``W`` and the traces
+live in the *carried state* (not a ``Param``). So an **outer loop** can
+meta-learn *how the layer learns*:
+
+* by **gradient** — :func:`flax.nnx.grad` through :meth:`apply_sequence`
+  differentiates a downstream meta-loss w.r.t. the coefficients (the inner
+  weight updates are ordinary differentiable ops), or
+* **gradient-free** — because the coefficients are the only ``nnx.Param``\ s,
+  they are exactly what ``spyx.experimental.hybrid`` / ``spyx.experimental.evolve``
+  perturb (both split on ``nnx.Param``), so ES / CMA-ES can meta-learn the rule
+  without differentiating through it.
+
+This is the ES-meta-learned-plasticity substrate: the *inner* learning is local,
+online and BPTT-free; only the *outer* optimisation of a handful of coefficients
+uses SGD or ES.
+
+Honest caveat: unlike :class:`spyx.experimental.PSU_LIF` /
+:class:`spyx.experimental.SigmaDelta`, this rule is **inherently sequential** in
+``O(T)`` — the membrane (and hence the pseudo-derivative and eligibility) depends
+on the running plastic ``W``, so there is no associative-scan shortcut. The
+eligibility trace *alone* is a linear leaky integrator (an associative scan) only
+when the drive is held fixed; coupling it back into ``W`` breaks that, by design.
+
+References
+----------
+* Bellec, Scherr, Subramoney, Hajek, Salaj, Legenstein & Maass, *A solution to
+  the learning dilemma for recurrent networks of spiking neurons*, Nature
+  Communications 11, 3625 (2020),
+  `doi:10.1038/s41467-020-17236-y
+  <https://www.nature.com/articles/s41467-020-17236-y>`_ (e-prop).
+* Xiao, Meng, Zhang, He & Lin, *Online Training Through Time for Spiking Neural
+  Networks*, NeurIPS 2022 (`arXiv:2210.04195
+  <https://arxiv.org/abs/2210.04195>`_) (OTTT; three-factor online form).
+* Sun, Li, Dalal, Xu, Vikram, Zhang, Dubois, Chen, Wang, Koyejo, Hashimoto &
+  Guestrin, *Learning to (Learn at Test Time): RNNs with Expressive Hidden
+  States*, ICML 2025 (`arXiv:2407.04620 <https://arxiv.org/abs/2407.04620>`_)
+  (TTT; the delta-rule inner update).
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from ..axn import superspike
+
+__all__ = ["surrogate_deriv", "ThreeFactorLIF"]
+
+# Default forward spike; its backward slope matches :func:`surrogate_deriv`.
+_DEFAULT_ACTIVATION = superspike()
+
+
+def surrogate_deriv(v: jax.Array, k: float = 25.0) -> jax.Array:
+    """Forward-computed postsynaptic pseudo-derivative ``h'(v) = 1/(1+k|v|)^2``.
+
+    This is the SuperSpike surrogate slope — identical to the backward function of
+    :func:`spyx.axn.superspike` — but evaluated as an ordinary forward quantity so
+    the eligibility trace can be built *without* a backward pass. ``v`` is the
+    membrane relative to threshold; larger ``k`` narrows the window in which a
+    synapse is eligible.
+    """
+    return 1.0 / (1.0 + k * jnp.abs(v)) ** 2
+
+
+def _expand_mod(mod: jax.Array) -> jax.Array:
+    """Broadcast a modulator to align with an ``(B, in, out)`` eligibility trace.
+
+    Accepts a per-sample signal ``(B,)`` -> ``(B, 1, 1)`` (gates every synapse of
+    a sample equally) or a per-postsynaptic-unit signal ``(B, out)`` ->
+    ``(B, 1, out)`` (a distinct learning signal per output neuron, as in e-prop).
+    """
+    if mod.ndim == 1:
+        return mod[:, None, None]
+    return mod[:, None, :]
+
+
+class ThreeFactorLIF(nnx.Module):
+    r"""Plastic-synapse LIF trained online by a local three-factor rule.
+
+    A leaky integrate-and-fire layer whose input weights ``W`` are **plastic**:
+    they are carried in the layer state and nudged every timestep by
+    ``ΔW = eta * <modulator * eligibility>`` (see the module docstring), so
+    learning happens *inside* the forward-through-time pass with no BPTT and no
+    stored activations.
+
+    Contract. :meth:`__call__` follows the Spyx ``(x, state) -> (out, new_state)``
+    shape, with ``x = (pre, mod)`` a two-tuple of the presynaptic input and the
+    per-step modulator — so it scans directly under :func:`jax.lax.scan`. Because
+    ``x`` is a pytree rather than a single array, drive it with :meth:`apply_sequence`
+    (its analogue of :meth:`spyx.experimental.PSU_LIF.parallel`) rather than
+    :func:`spyx.nn.run`.
+
+    :in_features: presynaptic width (input units).
+    :out_features: postsynaptic width (LIF units).
+    :eta: plasticity rate ``eta`` — learnable ``nnx.Param`` scalar.
+    :gamma: eligibility-trace decay ``gamma in [0, 1]`` — learnable ``nnx.Param``.
+        ``gamma = 0`` keeps no trace and recovers a delta-rule / TTT inner step.
+    :alpha: presynaptic-filter decay ``alpha in [0, 1]`` — learnable ``nnx.Param``.
+    :beta: membrane leak ``beta in [0, 1]`` — learnable ``nnx.Param``.
+    :threshold: fixed firing threshold ``v_th``.
+    :k: fixed SuperSpike slope for the forward pseudo-derivative ``psi``.
+    :activation: ``spyx.axn`` forward spike; defaults to ``superspike(k=25)`` so
+        its surrogate matches :func:`surrogate_deriv`.
+
+    The plastic ``W`` and the traces are **state**, not ``Param``\ s: the only
+    ``nnx.Param``\ s are the four coefficients, which is exactly what lets an outer
+    SGD/ES loop meta-learn the rule (see the module docstring).
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        eta: float = 0.01,
+        gamma: float = 0.9,
+        alpha: float = 0.9,
+        beta: float = 0.9,
+        threshold: float = 1.0,
+        k: float = 25.0,
+        activation=None,
+        rngs: nnx.Rngs | None = None,
+    ):
+        del rngs  # W starts at zeros; accepted for a uniform constructor.
+        self.in_features = in_features
+        self.out_features = out_features
+        self.threshold = float(threshold)
+        self.k = float(k)
+        self.spike = activation if activation is not None else _DEFAULT_ACTIVATION
+        # Rule coefficients — the meta-learnable surface (the ONLY nnx.Params).
+        self.eta = nnx.Param(jnp.full((), eta))
+        self.gamma = nnx.Param(jnp.full((), gamma))
+        self.alpha = nnx.Param(jnp.full((), alpha))
+        self.beta = nnx.Param(jnp.full((), beta))
+
+    def initial_state(self, batch_size: int):
+        """Fresh carry ``(V, pbar, e, W)`` for a batch (plastic ``W`` starts at 0).
+
+        ``V`` membrane ``(B, out)``, ``pbar`` presynaptic trace ``(B, in)``, ``e``
+        eligibility ``(B, in, out)``, ``W`` plastic weight ``(in, out)`` shared
+        across the batch. To warm-start ``W`` (e.g. a meta-learned init), build the
+        tuple yourself and pass it as ``state`` to :meth:`apply_sequence`.
+        """
+        V = jnp.zeros((batch_size, self.out_features))
+        pbar = jnp.zeros((batch_size, self.in_features))
+        e = jnp.zeros((batch_size, self.in_features, self.out_features))
+        W = jnp.zeros((self.in_features, self.out_features))
+        return V, pbar, e, W
+
+    def __call__(self, x, state):
+        r"""One online step ``((pre, mod), state) -> (spikes, new_state)``.
+
+        Integrates the drive through the *current* plastic ``W``, emits a spike,
+        forms the eligibility trace from the presynaptic trace and the forward
+        pseudo-derivative, then applies the modulated weight update — all in the
+        forward pass. ``pre`` is ``(B, in)``; ``mod`` is ``(B,)`` or ``(B, out)``.
+        """
+        pre, mod = x
+        V, pbar, e, W = state
+        gamma = jnp.clip(self.gamma[...], 0, 1)
+        alpha = jnp.clip(self.alpha[...], 0, 1)
+        beta = jnp.clip(self.beta[...], 0, 1)
+
+        # Drive and membrane use the current (pre-update) plastic weight.
+        drive = pre @ W  # (B, out)
+        V = beta * V + drive
+        v = V - self.threshold
+        spikes = self.spike(v)  # forward Heaviside, surrogate backward
+        psi = surrogate_deriv(v, self.k)  # (B, out) forward pseudo-derivative
+
+        # Three factors: presynaptic trace, postsynaptic psi, decaying coincidence.
+        pbar = alpha * pbar + pre  # (B, in)
+        coincidence = pbar[:, :, None] * psi[:, None, :]  # (B, in, out) outer product
+        e = gamma * e + coincidence
+
+        # Modulated, batch-averaged update — applied DURING the forward pass.
+        dW = self.eta[...] * jnp.mean(_expand_mod(mod) * e, axis=0)  # (in, out)
+        W = W + dW
+        return spikes, (V, pbar, e, W)
+
+    def apply_sequence(self, pre, mod, state=None):
+        r"""Stream a whole time-major sequence, learning ``W`` online as it goes.
+
+        :pre: presynaptic input ``(T, B, in)``.
+        :mod: per-step modulator ``(T, B)`` or ``(T, B, out)``.
+        :state: optional initial carry (defaults to :meth:`initial_state`); pass
+            a hand-built tuple to warm-start the plastic ``W``.
+        :return: ``(spikes, final_state)`` with ``spikes`` ``(T, B, out)`` and
+            ``final_state`` the ``(V, pbar, e, W)`` carry whose ``W`` is the weight
+            *learned* by the local rule over the sequence.
+
+        This is the driver analogue of :meth:`spyx.experimental.PSU_LIF.parallel`;
+        it is an ``O(T)`` :func:`jax.lax.scan` (the rule is sequential by design).
+        Differentiating a loss on its output w.r.t. the coefficients meta-learns
+        the rule; evaluating it forward-only lets ES do the same.
+        """
+        if state is None:
+            state = self.initial_state(pre.shape[1])
+
+        def step(carry, xt):
+            spikes, carry = self(xt, carry)
+            return carry, spikes
+
+        final_state, spikes = jax.lax.scan(step, state, (pre, mod))
+        return spikes, final_state

--- a/src/spyx/experimental/ttt.py
+++ b/src/spyx/experimental/ttt.py
@@ -1,0 +1,209 @@
+r"""Test-time-training fast-weight sequence layer — the hidden *state is a weight*.
+
+A conventional recurrent layer carries a hidden *vector*; a **fast-weight** /
+test-time-training (TTT) layer carries a small hidden *matrix* ``W_t`` and treats
+each incoming token as a tiny supervised example, taking one online learning step
+on ``W`` as the sequence streams. The token is projected by *slow* (ordinary,
+backprop-trained) weights into a key ``k_t``, a value/target ``v_t`` and a query
+``q_t``; the fast weights are updated toward mapping ``k_t -> v_t`` and then read
+out with ``q_t``. This is the "fast-weight programmer" view of linear attention
+(Schlag, Irie & Schmidhuber 2021) and the TTT-Linear layer of Sun et al. 2024,
+where the hidden state is itself a linear model updated by self-supervised
+gradient descent.
+
+Two write rules are provided, and the distinction is the whole point of putting
+this in a *parallel* spiking library:
+
+* ``rule="hebb"`` — the purely additive outer-product write
+
+  .. math::
+      W_t = \lambda \, W_{t-1} + \eta \, v_t k_t^\top .
+
+  The transition is a **scalar** (``lambda``), so this is a first-order *affine*
+  recurrence in the matrix state — associative in exactly the sense
+  :data:`spyx.nn._leaky_associative_op` exploits — and the whole sequence is an
+  ``O(log T)`` :func:`jax.lax.associative_scan`, matrix-valued sibling of
+  :class:`spyx.experimental.PSU_LIF` / :class:`spyx.experimental.SigmaDelta`.
+
+* ``rule="delta"`` — the error-correcting *delta rule* (Schlag 2021, Sun 2024)
+
+  .. math::
+      W_t = \lambda \, W_{t-1}
+            + \eta \, (v_t - W_{t-1} k_t)\, k_t^\top
+          = W_{t-1}\,(\lambda I - \eta\, k_t k_t^\top) + \eta\, v_t k_t^\top .
+
+  It writes the *residual* ``v_t - pred_t`` instead of ``v_t``, so the fast
+  weights correct their current key->value mapping rather than just accumulate.
+  It is still linear in ``W``, but the transition ``M_t = \lambda I -
+  \eta k_t k_t^\top`` is now a **matrix**, not a scalar.
+
+Honest parallelism boundary: matrix-affine maps are still associative
+(``(M_i, B_i) ∘ (M_j, B_j) = (M_i M_j, B_i M_j + B_j)``), but each
+``associative_scan`` combine then costs a ``key×key`` matrix–matrix product
+``O(d_k^3)`` and stores ``T`` such matrices (``O(T d_k^2)`` memory) — so a *naive*
+scan is not a win. The hardware-efficient parallel form of the delta rule is the
+**chunked** WY / Householder algorithm of Yang et al. 2024 (DeltaNet), which is
+out of scope here. Accordingly :meth:`TTTFastWeight.parallel` is implemented only
+for ``rule="hebb"`` (scalar transition, genuinely cheap); for ``rule="delta"``
+use the sequential :meth:`__call__` via :func:`spyx.nn.run`, and reach for chunked
+DeltaNet if you need the parallel speed-up.
+
+Both execution modes for ``rule="hebb"`` are numerically identical: scanning
+:meth:`__call__` over time reproduces :meth:`parallel` exactly (same slow
+projections, same ``eta``/``lambda``, read-out taken *after* the write in both).
+
+References:
+
+* Sun, Li, Dalal, Xu, Xu, Xie, et al., *Learning to (Learn at Test Time): RNNs
+  with Expressive Hidden States*, 2024
+  (`arXiv:2407.04620 <https://arxiv.org/abs/2407.04620>`_).
+* Schlag, Irie & Schmidhuber, *Linear Transformers Are Secretly Fast Weight
+  Programmers*, ICML 2021
+  (`arXiv:2102.11174 <https://arxiv.org/abs/2102.11174>`_).
+* Yang, Wang, Zhang, Shen & Kim, *Parallelizing Linear Transformers with the
+  Delta Rule over Sequence Length*, NeurIPS 2024
+  (`arXiv:2406.06484 <https://arxiv.org/abs/2406.06484>`_) — the chunked parallel
+  form of ``rule="delta"``.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from ..nn import _leaky_associative_op
+
+__all__ = ["TTTFastWeight"]
+
+
+class TTTFastWeight(nnx.Module):
+    r"""Fast-weight / test-time-training sequence layer (matrix hidden state).
+
+    The hidden state carried through the sequence is a fast-weight matrix
+    ``W_t`` of shape ``(batch, val_dim, key_dim)`` — *not* a learnable parameter,
+    but a state updated online from the stream. The learnable (*slow*) parameters
+    are the input projections ``W_k``, ``W_v``, ``W_q`` and the read-out
+    projection ``W_o``; ``eta`` (the online learning rate) is a learnable scalar.
+    Gradients from a downstream loss flow into all of these through the unrolled
+    (or scanned) recurrence.
+
+    Per step ``(x_t, W) -> (out_t, W_new)``:
+
+    #. project ``k_t = W_k x_t``, ``v_t = W_v x_t``, ``q_t = W_q x_t``;
+    #. write the fast weights with the selected ``rule`` (see below);
+    #. read out ``y_t = W_new q_t`` and project ``out_t = W_o y_t``.
+
+    Following the ``(x, state) -> (out, new_state)`` contract, it drops straight
+    into :class:`spyx.nn.Sequential` and :func:`spyx.nn.run`.
+
+    :in_features: input feature dimension.
+    :out_features: output feature dimension.
+    :key_dim: key/query dimension (fast-weight columns). Defaults to
+        ``in_features``.
+    :val_dim: value dimension (fast-weight rows). Defaults to ``out_features``.
+    :eta: online learning rate of the fast-weight write. Learnable scalar
+        (initialised to this value); used identically in both execution modes.
+    :decay: fast-weight leak ``lambda`` in ``[0, 1]``. Fixed (not learned) to
+        keep the recurrence's scalar transition stable; ``1.0`` is a pure
+        (undecayed) associative memory.
+    :rule: ``"hebb"`` for the additive outer-product write (scalar transition,
+        ``.parallel`` associative-scan available) or ``"delta"`` for the
+        error-correcting delta rule (matrix transition; sequential only here).
+
+    Honest caveat: with ``decay=1.0`` and no key normalisation the additive rule
+    is an unbounded associative memory — repeated keys accumulate — so long
+    sequences may need ``decay < 1`` or unit-norm keys. The delta rule is
+    self-stabilising (it subtracts its own prediction) but is not cheaply
+    parallel here; that is the deliberate trade, mirroring reset-free vs. reset
+    in the parallel LIF neurons.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        key_dim: int | None = None,
+        val_dim: int | None = None,
+        eta: float = 0.5,
+        decay: float = 1.0,
+        rule: str = "delta",
+        *,
+        rngs: nnx.Rngs,
+    ):
+        if rule not in ("hebb", "delta"):
+            raise ValueError(f"rule must be 'hebb' or 'delta', got {rule!r}")
+        self.in_features = in_features
+        self.out_features = out_features
+        self.key_dim = key_dim if key_dim is not None else in_features
+        self.val_dim = val_dim if val_dim is not None else out_features
+        self.decay = float(decay)
+        self.rule = rule
+
+        self.eta = nnx.Param(jnp.full((), float(eta)))
+        self.W_k = nnx.Linear(in_features, self.key_dim, rngs=rngs)
+        self.W_v = nnx.Linear(in_features, self.val_dim, rngs=rngs)
+        self.W_q = nnx.Linear(in_features, self.key_dim, rngs=rngs)
+        self.W_o = nnx.Linear(self.val_dim, out_features, rngs=rngs)
+
+    def __call__(self, x, W):
+        """One online step ``(x_t, W) -> (out_t, W_new)``.
+
+        Projects ``x_t`` to ``(k, v, q)``, writes the fast weights with the
+        selected ``rule``, then reads out with the query. Scanning this over time
+        via :func:`spyx.nn.run` reproduces :meth:`parallel` exactly for
+        ``rule="hebb"``.
+        """
+        k = self.W_k(x)  # (B, key_dim)
+        v = self.W_v(x)  # (B, val_dim)
+        q = self.W_q(x)  # (B, key_dim)
+        eta = self.eta[...]
+
+        if self.rule == "delta":
+            pred = jnp.einsum("bvk,bk->bv", W, k)  # W_{t-1} k_t
+            write = eta * jnp.einsum("bv,bk->bvk", v - pred, k)
+        else:  # "hebb"
+            write = eta * jnp.einsum("bv,bk->bvk", v, k)
+        W_new = self.decay * W + write
+
+        y = jnp.einsum("bvk,bk->bv", W_new, q)  # read with the query
+        return self.W_o(y), W_new
+
+    def initial_state(self, batch_size):
+        return jnp.zeros((batch_size, self.val_dim, self.key_dim))
+
+    def parallel(self, x):
+        r"""Score a whole time-major ``[T, B, in]`` sequence with an associative scan.
+
+        Only defined for ``rule="hebb"``: the additive write has a **scalar**
+        transition ``lambda``, so the fast-weight trace
+        ``W_t = lambda W_{t-1} + eta v_t k_t^T`` (with ``W_{-1} = 0``) is a
+        matrix-valued affine recurrence and folds with
+        :func:`jax.lax.associative_scan` via
+        :data:`spyx.nn._leaky_associative_op` in ``O(log T)`` depth — the same
+        parallel primitive as :class:`spyx.experimental.PSU_LIF`, with a matrix
+        increment in place of a scalar. Read-out ``y_t = W_t q_t`` is then a
+        pointwise batched mat-vec.
+
+        For ``rule="delta"`` the transition is a ``key×key`` matrix, so a naive
+        scan is ``O(T d_k^3)`` work / ``O(T d_k^2)`` memory rather than a win;
+        this raises, pointing you to sequential :func:`spyx.nn.run` (or the
+        chunked DeltaNet algorithm, Yang et al. 2024).
+        """
+        if self.rule != "hebb":
+            raise NotImplementedError(
+                "parallel() is only available for rule='hebb' (scalar transition). "
+                "The delta rule has a matrix transition; scan it sequentially with "
+                "spyx.nn.run, or use the chunked DeltaNet form (arXiv:2406.06484)."
+            )
+        k = self.W_k(x)  # (T, B, key_dim)
+        v = self.W_v(x)  # (T, B, val_dim)
+        q = self.W_q(x)  # (T, B, key_dim)
+
+        # Per-step matrix increment eta * outer(v_t, k_t): (T, B, val, key).
+        b = self.eta[...] * jnp.einsum("tbv,tbk->tbvk", v, k)
+        # Scalar transition lambda broadcast to the (T, B, 1, 1) leading shape so
+        # the affine-map coefficient A_t == lambda for every element.
+        A = jnp.broadcast_to(jnp.asarray(self.decay), b.shape[:2] + (1, 1))
+        _, W = jax.lax.associative_scan(_leaky_associative_op, (A, b), axis=0)
+        return self.W_o(jnp.einsum("tbvk,tbk->tbv", W, q))

--- a/tests/test_feedback_alignment.py
+++ b/tests/test_feedback_alignment.py
@@ -1,0 +1,186 @@
+"""Feedback Alignment / Direct FA: exact forward, sign/angle alignment, learning."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from flax import nnx
+
+import spyx.nn as snn
+from spyx.experimental.feedback_alignment import (
+    FALinear,
+    dfa_gradient,
+    fa_dense,
+)
+
+
+def _cos(a, b):
+    a, b = a.reshape(-1), b.reshape(-1)
+    return float(a @ b / (jnp.linalg.norm(a) * jnp.linalg.norm(b) + 1e-12))
+
+
+def test_fa_forward_matches_linear():
+    """FALinear's forward equals nnx.Linear with the same weight and bias."""
+    in_f, out_f = 12, 7
+    lin = nnx.Linear(in_f, out_f, rngs=nnx.Rngs(0))
+    fa = FALinear(in_f, out_f, rngs=nnx.Rngs(1))
+    fa.weight = nnx.Param(lin.kernel[...])
+    fa.bias = nnx.Param(lin.bias[...])
+    x = jax.random.normal(jax.random.PRNGKey(2), (5, in_f))
+    assert jnp.allclose(fa(x), lin(x), atol=1e-6)
+
+
+def test_fa_dense_backward_uses_feedback_not_transpose():
+    """fa_dense input-grad is g @ feedback, weight-grad stays exact (x^T g)."""
+    x = jax.random.normal(jax.random.PRNGKey(0), (4, 6))
+    w = jax.random.normal(jax.random.PRNGKey(1), (6, 3))
+    b = jax.random.normal(jax.random.PRNGKey(2), (3, 6))  # feedback (out, in)
+    g = jax.random.normal(jax.random.PRNGKey(3), (4, 3))
+    _, vjp = jax.vjp(lambda x_, w_: fa_dense(x_, w_, b), x, w)
+    dx, dw = vjp(g)
+    assert jnp.allclose(dx, g @ b, atol=1e-6)  # random feedback, not g @ w.T
+    assert jnp.allclose(dw, x.T @ g, atol=1e-6)  # weight grad exact
+
+
+def _fa_mlp(seed):
+    """Feedforward spiking MLP with FALinear layers (PSU_LIF fires on drive)."""
+    r = nnx.Rngs(seed)
+    return snn.Sequential(
+        FALinear(8, 16, rngs=r),
+        snn.PSU_LIF((16,), beta=0.0, threshold=0.0, rngs=r),
+        FALinear(16, 3, rngs=r),
+    )
+
+
+def _bp_mirror(fa_model):
+    """A plain-Linear twin of an FA MLP sharing its forward weights (BP ref)."""
+    r = nnx.Rngs(99)
+    lin0 = nnx.Linear(8, 16, rngs=r)
+    lin0.kernel = nnx.Param(fa_model.layers[0].weight[...])
+    lin0.bias = nnx.Param(fa_model.layers[0].bias[...])
+    lin1 = nnx.Linear(16, 3, rngs=r)
+    lin1.kernel = nnx.Param(fa_model.layers[2].weight[...])
+    lin1.bias = nnx.Param(fa_model.layers[2].bias[...])
+    return snn.Sequential(
+        lin0, snn.PSU_LIF((16,), beta=0.0, threshold=0.0, rngs=r), lin1
+    )
+
+
+def _feedforward(model, x):
+    h = x
+    for layer in model.layers:
+        if hasattr(layer, "initial_state"):
+            h, _ = layer(h, layer.initial_state(x.shape[0]))
+        else:
+            h = layer(h)
+    return h
+
+
+def _ce(logits, y):
+    return jnp.mean(optax.softmax_cross_entropy_with_integer_labels(logits, y))
+
+
+def test_fa_gradient_sign_alignment_and_learning():
+    """FA aligns with BP in sign/angle and the loss decreases while training."""
+    key = jax.random.PRNGKey(0)
+    kx, ky = jax.random.split(key)
+    x = jax.random.normal(kx, (64, 8))
+    w_true = jax.random.normal(ky, (8, 3))
+    y = jnp.argmax(x @ w_true, axis=-1)
+
+    fa = _fa_mlp(1)
+
+    def fa_loss(m):
+        return _ce(_feedforward(m, x), y)
+
+    def bp_loss_of(m):
+        return _ce(_feedforward(m, x), y)
+
+    tx = optax.sgd(0.2)
+    opt = nnx.Optimizer(fa, tx, wrt=nnx.Param)
+    loss0 = float(fa_loss(fa))
+
+    cos_hidden = []
+    for _ in range(40):
+        grads = nnx.grad(fa_loss)(fa)
+        # Compare the FA hidden-weight grad against the true-BP hidden-weight grad.
+        bp = _bp_mirror(fa)
+        g_bp = nnx.grad(bp_loss_of)(bp)
+        g_fa_h = grads["layers"][0]["weight"][...]
+        g_bp_h = g_bp["layers"][0]["kernel"][...]
+        cos_hidden.append(_cos(g_fa_h, g_bp_h))
+        opt.update(fa, grads)
+
+    loss1 = float(fa_loss(fa))
+    assert loss1 < loss0  # FA actually trains
+    # Alignment: the FA hidden pseudo-gradient acquires a positive projection on BP.
+    assert np.mean(cos_hidden[-10:]) > 0.0
+    # Sign agreement of the two hidden gradients is better than chance.
+    g_fa_h = nnx.grad(fa_loss)(fa)["layers"][0]["weight"][...]
+    bp = _bp_mirror(fa)
+    g_bp_h = nnx.grad(bp_loss_of)(bp)["layers"][0]["kernel"][...]
+    sign_agree = float(jnp.mean(jnp.sign(g_fa_h) == jnp.sign(g_bp_h)))
+    assert sign_agree > 0.5
+
+
+def test_dfa_reaches_nontrivial_accuracy():
+    """DFA trains a feedforward spiking MLP to well above chance on a 3-way task."""
+    key = jax.random.PRNGKey(0)
+    kx, kw = jax.random.split(key)
+    x = jax.random.normal(kx, (96, 8))
+    w_true = jax.random.normal(kw, (8, 3))
+    y = jnp.argmax(x @ w_true, axis=-1)
+
+    r = nnx.Rngs(3)
+    model = snn.Sequential(
+        nnx.Linear(8, 32, rngs=r),
+        snn.PSU_LIF((32,), beta=0.0, threshold=0.0, rngs=r),
+        nnx.Linear(32, 32, rngs=r),
+        snn.PSU_LIF((32,), beta=0.0, threshold=0.0, rngs=r),
+        nnx.Linear(32, 3, rngs=r),
+    )
+    # One fixed random feedback per hidden neuron, shape (n_out=3, hidden).
+    fk = jax.random.split(jax.random.PRNGKey(7), 2)
+    feedbacks = [
+        jax.random.normal(fk[0], (3, 32)) * 0.1,
+        jax.random.normal(fk[1], (3, 32)) * 0.1,
+    ]
+
+    tx = optax.adam(3e-3)
+    opt = nnx.Optimizer(model, tx, wrt=nnx.Param)
+
+    def accuracy():
+        return float(jnp.mean(jnp.argmax(_feedforward(model, x), -1) == y))
+
+    acc0 = accuracy()
+    for _ in range(200):
+        grads = dfa_gradient(model, x, y, feedbacks, loss_fn=_ce)
+        opt.update(model, grads)
+    acc1 = accuracy()
+
+    assert acc1 > acc0
+    assert acc1 > 0.6  # non-trivial: well above the 1/3 chance floor
+
+
+def test_falinear_composes_with_run_over_time():
+    """FALinear drops into spyx.nn.run; BPTT differentiates through fa_dense."""
+    T, B, C, H = 10, 4, 6, 8
+    r = nnx.Rngs(0)
+    net = snn.Sequential(
+        FALinear(C, H, rngs=r),
+        snn.LIF((H,), beta=0.8, rngs=r),
+        FALinear(H, 3, rngs=r),
+        snn.LI((3,), beta=0.8, rngs=r),
+    )
+    x = jax.random.normal(jax.random.PRNGKey(1), (T, B, C))
+    y = jnp.zeros((B,), dtype=jnp.int32)
+
+    def loss(m):
+        out, _ = snn.run(m, x)
+        return _ce(jnp.sum(out, axis=0), y)
+
+    grads = nnx.grad(loss)(net)
+    # A finite FA gradient flows to the first FALinear's weight through the scan.
+    g0 = grads["layers"][0]["weight"][...]
+    assert jnp.all(jnp.isfinite(g0))
+    assert float(jnp.linalg.norm(g0)) > 0.0

--- a/tests/test_local_learning.py
+++ b/tests/test_local_learning.py
@@ -1,0 +1,127 @@
+"""Local three-factor (e-prop/OTTT-style) plasticity: trace decay, online
+association learning, and meta-learnable/evolvable coefficients.
+
+None of these download data, so no ``@pytest.mark.network``.
+"""
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from spyx.experimental.hybrid import es_gradient
+from spyx.experimental.local_learning import ThreeFactorLIF, surrogate_deriv
+
+
+def test_surrogate_deriv_matches_superspike():
+    """The forward pseudo-derivative equals SuperSpike's backward slope."""
+    v = jnp.linspace(-2.0, 2.0, 11)
+    assert jnp.allclose(surrogate_deriv(v, 25.0), 1.0 / (1.0 + 25.0 * jnp.abs(v)) ** 2)
+    # peaks at the threshold (v == 0) and decays away from it.
+    assert float(surrogate_deriv(jnp.array(0.0))) == 1.0
+    assert float(surrogate_deriv(jnp.array(1.0))) < float(
+        surrogate_deriv(jnp.array(0.1))
+    )
+
+
+def test_eligibility_trace_decays_by_gamma():
+    """With no pre-filter memory, a pre pulse then silence gives geometric decay.
+
+    Setting ``alpha = 0`` makes ``pbar_t = pre_t``, so after the input stops the
+    coincidence term is zero and ``e_t = gamma * e_{t-1}`` exactly. ``eta = 0``
+    freezes ``W`` so the drive (and thus ``psi``) never changes the test.
+    """
+    B, IN, OUT = 1, 3, 2
+    gamma = 0.7
+    layer = ThreeFactorLIF(
+        IN, OUT, eta=0.0, gamma=gamma, alpha=0.0, beta=0.5, threshold=0.0
+    )
+    T = 6
+    pre = jnp.zeros((T, B, IN)).at[0].set(1.0)  # single pulse at t=0
+    mod = jnp.ones((T, B))
+
+    # Manually scan to inspect the eligibility trace at every step.
+    state = layer.initial_state(B)
+    traces = []
+    for t in range(T):
+        _, state = layer((pre[t], mod[t]), state)
+        traces.append(state[2])  # e is the third carry element
+    e = jnp.stack(traces)
+
+    peak = float(jnp.max(jnp.abs(e[0])))
+    assert peak > 0.0  # the pulse created eligibility
+    for t in range(1, T - 1):
+        ratio = jnp.abs(e[t + 1]) / (jnp.abs(e[t]) + 1e-12)
+        assert jnp.allclose(ratio[jnp.abs(e[t]) > 1e-9], gamma, atol=1e-5)
+
+
+def test_reward_modulated_rule_learns_association():
+    """A hand-set positive-reward rule strengthens the driven synapse online.
+
+    Input unit 0 is active every step; with a positive modulator the three-factor
+    update should grow ``W[0, :]`` (the eligible synapses) while the silent input
+    unit 1's weights stay put — a trivial reward-modulated association.
+    """
+    B, IN, OUT = 4, 2, 3
+    layer = ThreeFactorLIF(
+        IN, OUT, eta=0.05, gamma=0.9, alpha=0.5, beta=0.0, threshold=0.0
+    )
+    T = 30
+    pre = jnp.zeros((T, B, IN)).at[:, :, 0].set(1.0)  # only input 0 fires
+    mod = jnp.ones((T, B))  # constant positive reward
+
+    # Warm-start W slightly positive so the neuron is driven from the first step.
+    V, pbar, e, W = layer.initial_state(B)
+    W = W + 0.1
+    _, (_, _, _, W_final) = layer.apply_sequence(pre, mod, (V, pbar, e, W))
+
+    # The active input's synapses grew; the silent input's did not.
+    assert jnp.all(W_final[0] > W[0] + 1e-3)
+    assert jnp.allclose(W_final[1], W[1])
+    # A negative modulator drives the same synapses the other way.
+    _, (_, _, _, W_neg) = layer.apply_sequence(pre, -mod, (V, pbar, e, W))
+    assert jnp.all(W_neg[0] < W[0] - 1e-3)
+
+
+def _meta_loss(layer, pre, mod, target):
+    """Meta-objective: drive the online-learned W toward a target matrix."""
+    _, (_, _, _, W_final) = layer.apply_sequence(pre, mod)
+    return jnp.mean((W_final - target) ** 2)
+
+
+def test_coefficients_are_differentiable():
+    """A meta-loss on the learned W has finite, nonzero grads w.r.t. the coeffs."""
+    B, IN, OUT, T = 3, 2, 2, 12
+    layer = ThreeFactorLIF(IN, OUT, threshold=0.0, beta=0.0)
+    key = jax.random.PRNGKey(0)
+    pre = jax.random.bernoulli(key, 0.5, (T, B, IN)).astype(jnp.float32)
+    mod = jnp.ones((T, B))
+    target = jnp.ones((IN, OUT)) * 0.2
+
+    grads = nnx.grad(_meta_loss)(layer, pre, mod, target)
+    leaves = [jnp.asarray(g) for g in jax.tree.leaves(grads)]
+    assert leaves and all(bool(jnp.all(jnp.isfinite(g))) for g in leaves)
+    assert any(bool(jnp.any(g != 0.0)) for g in leaves)
+
+
+def test_coefficients_are_evolvable():
+    """The coeffs are the only nnx.Params, so ES (forward-only) reaches them."""
+    B, IN, OUT, T = 3, 2, 2, 12
+    layer = ThreeFactorLIF(IN, OUT, threshold=0.0, beta=0.0)
+    key = jax.random.PRNGKey(1)
+    pre = jax.random.bernoulli(key, 0.5, (T, B, IN)).astype(jnp.float32)
+    mod = jnp.ones((T, B))
+    target = jnp.ones((IN, OUT)) * 0.2
+
+    # Only eta/gamma/alpha/beta are Params; W and the traces are carried state.
+    _, params, _ = nnx.split(layer, nnx.Param, ...)
+    assert len(jax.tree.leaves(params)) == 4
+
+    grads = es_gradient(
+        layer,
+        lambda m: _meta_loss(m, pre, mod, target),
+        key,
+        num_samples=4,
+        sigma=0.02,
+    )
+    leaves = [jnp.asarray(g) for g in jax.tree.leaves(grads)]
+    assert leaves and all(bool(jnp.all(jnp.isfinite(g))) for g in leaves)

--- a/tests/test_ttt.py
+++ b/tests/test_ttt.py
@@ -1,0 +1,143 @@
+"""TTT fast-weight layer: hebb parallel==sequential, delta sequential-only, gradients."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+import spyx.nn as snn
+from spyx.experimental import TTTFastWeight
+
+
+def _seq_scan(layer, x):
+    """Reference: scan ``__call__`` over time and stack the outputs."""
+    W = layer.initial_state(x.shape[1])
+    outs = []
+    for t in range(x.shape[0]):
+        out, W = layer(x[t], W)
+        outs.append(out)
+    return jnp.stack(outs)
+
+
+@pytest.mark.parametrize("decay", [0.9, 1.0])
+@pytest.mark.parametrize("eta", [0.3, 1.0])
+def test_hebb_parallel_equals_sequential(decay, eta):
+    """The hebb ``.parallel`` associative scan == scanning ``__call__`` over time."""
+    T, B, C, OUT, KD, VD = 32, 6, 5, 7, 4, 9  # non-square, distinct dims
+    layer = TTTFastWeight(
+        C,
+        OUT,
+        key_dim=KD,
+        val_dim=VD,
+        eta=eta,
+        decay=decay,
+        rule="hebb",
+        rngs=nnx.Rngs(0),
+    )
+    x = jax.random.normal(jax.random.PRNGKey(1), (T, B, C))
+    s_par = layer.parallel(x)
+    s_seq = _seq_scan(layer, x)
+    assert s_par.shape == (T, B, OUT)
+    # Equal in exact arithmetic; at decay=eta=1.0 the fast weights grow (the
+    # documented unbounded-memory regime), so the tree-reduction scan and the
+    # left-fold sequential differ only by float32 reassociation -> relative tol.
+    assert jnp.allclose(s_par, s_seq, rtol=1e-4, atol=1e-5)
+
+
+def test_delta_parallel_raises():
+    """The delta rule has a matrix transition — ``.parallel`` refuses, points to run."""
+    layer = TTTFastWeight(5, 5, rule="delta", rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.PRNGKey(1), (8, 3, 5))
+    with pytest.raises(NotImplementedError, match="spyx.nn.run"):
+        layer.parallel(x)
+
+
+def test_invalid_rule_raises():
+    with pytest.raises(ValueError, match="hebb"):
+        TTTFastWeight(4, 4, rule="bogus", rngs=nnx.Rngs(0))
+
+
+def test_initial_state_shape():
+    layer = TTTFastWeight(6, 3, key_dim=4, val_dim=5, rngs=nnx.Rngs(0))
+    W = layer.initial_state(8)
+    assert W.shape == (8, 5, 4)
+    assert jnp.all(W == 0.0)
+
+
+@pytest.mark.parametrize("rule", ["hebb", "delta"])
+def test_drops_into_run(rule):
+    """Both rules honour the (x, state) -> (out, new_state) contract under run."""
+    T, B, C, H = 12, 4, 6, 8
+    net = snn.Sequential(
+        nnx.Linear(C, H, rngs=nnx.Rngs(0)),
+        TTTFastWeight(H, H, rule=rule, rngs=nnx.Rngs(1)),
+        nnx.Linear(H, 3, rngs=nnx.Rngs(2)),
+        snn.LI((3,), rngs=nnx.Rngs(3)),
+    )
+    x = jax.random.normal(jax.random.PRNGKey(4), (T, B, C))
+    out, _ = snn.run(net, x)
+    assert out.shape == (T, B, 3)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_gradient_flows_to_slow_params():
+    """A downstream loss reaches every slow param through the fast-weight recurrence."""
+    T, B, C, OUT = 16, 4, 5, 3
+    layer = TTTFastWeight(C, OUT, eta=0.5, decay=0.9, rule="hebb", rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.PRNGKey(1), (T, B, C))
+
+    def loss(m):
+        return jnp.mean(m.parallel(x) ** 2)
+
+    grads = nnx.grad(loss)(layer)
+    leaves = [jnp.asarray(g) for g in jax.tree.leaves(grads)]
+    assert leaves and all(bool(jnp.all(jnp.isfinite(g))) for g in leaves)
+    assert any(bool(jnp.any(g != 0.0)) for g in leaves)
+
+
+def test_delta_gradient_flows_through_sequential():
+    """The delta rule's online recurrence still passes gradient to eta / projections."""
+    T, B, C, OUT = 14, 4, 5, 3
+    layer = TTTFastWeight(C, OUT, eta=0.3, rule="delta", rngs=nnx.Rngs(0))
+    x = jax.random.normal(jax.random.PRNGKey(1), (T, B, C))
+
+    def loss(m):
+        return jnp.mean(_seq_scan(m, x) ** 2)
+
+    grads = nnx.grad(loss)(layer)
+    assert bool(jnp.any(jnp.asarray(grads["eta"][...]) != 0.0))
+    assert bool(jnp.any(grads["W_k"]["kernel"][...] != 0.0))
+
+
+def test_delta_corrects_repeated_association():
+    """On a repeated (implicit) key the delta rule's prediction error shrinks.
+
+    Uses a small ``eta`` so ``eta*||k||^2 < 2`` and the delta transition
+    ``(1 - eta k k^T)`` is contractive — the stable regime the docstring warns must
+    be respected (large ``eta`` makes the fast weights expansive and diverge).
+    """
+    T, B, C, OUT = 40, 1, 4, 4
+    x = jnp.broadcast_to(
+        jax.random.normal(jax.random.PRNGKey(0), (C,)), (T, B, C)
+    )  # a held (redundant) token -> a repeated key/value
+    delta = TTTFastWeight(
+        C,
+        OUT,
+        key_dim=C,
+        val_dim=OUT,
+        eta=0.1,
+        decay=1.0,
+        rule="delta",
+        rngs=nnx.Rngs(1),
+    )
+
+    # track the internal prediction error |v - W_{t-1} k| over the sequence
+    W = delta.initial_state(B)
+    errs = []
+    for t in range(T):
+        k = delta.W_k(x[t])
+        v = delta.W_v(x[t])
+        errs.append(float(jnp.mean(jnp.abs(v - jnp.einsum("bvk,bk->bv", W, k)))))
+        _, W = delta(x[t], W)
+    # the delta rule drives its own prediction error down on a repeated key.
+    assert errs[-1] < errs[0]


### PR DESCRIPTION
Rebased onto `main` after #79 merged (supersedes #80, which GitHub auto-closed when its stacked base branch was deleted). Diff is now exactly this work — three modules, tests, docs, and the scout record.

## What

Three backprop-free / online-learning building blocks in `spyx.experimental`, each a JAX/nnx implementation of a **published** method (cited, not a novelty claim):

- **`ttt.TTTFastWeight`** — test-time-training / fast-weight layer whose hidden **state is a weight matrix** updated online per token. `rule="hebb"` has a *scalar* transition → an exact `associative_scan` `.parallel` path (a matrix-valued `PSU_LIF`); `rule="delta"` (error-correcting) has a *matrix* transition, is sequential-only here, and raises with a pointer to chunked DeltaNet. *(Sun 2024 [2407.04620](https://arxiv.org/abs/2407.04620); Schlag 2021 [2102.11174](https://arxiv.org/abs/2102.11174); Yang 2024 [2406.06484](https://arxiv.org/abs/2406.06484))*
- **`local_learning.ThreeFactorLIF`** — online **e-prop/OTTT** three-factor plasticity: eligibility trace + modulator-gated `ΔW` applied *during* the forward pass (no BPTT, no stored activations). Rule coefficients are the only `nnx.Param`s, so `spyx.experimental.hybrid`/`evolve` (ES) can meta-learn the rule. The spiking sibling of the TTT delta rule. *(Bellec 2020; Xiao 2022 [2210.04195](https://arxiv.org/abs/2210.04195))*
- **`feedback_alignment`** — FA (`FALinear`/`fa_dense`) and DFA (`dfa_inject`/`dfa_gradient`) via `jax.custom_vjp` random-feedback backward, composing with surrogate spiking neurons and `spyx.nn.run`. *(Lillicrap 2016; Nøkland 2016)*

## Novelty scout (the honest headline)

Built alongside an 11-agent scout + **adversarial** verification of whether *"ES-meta-learned spiking plasticity"* is unclaimed. Verdict — **CLAIMED, 3/3 skeptics, high confidence**: Confavreux et al. (PLOS Comp Biol 2025, CMA-ES) and Jordan et al. (eLife 2021, genetic programming) both already do ES × local-plasticity × spiking. Only the associative-scan-parallel *framing* is residual (an efficiency delta, not a capability). Recorded in `research/new/es_meta_plasticity_scout/` + FINDINGS (❌) so it isn't re-litigated. **We do not claim novelty** — these ship as cited building blocks that make that residual cheap to try.

## Verification

- **22 new tests**: hebb `parallel==sequential`, delta sequential-only + error-correction, FA↔BP sign/angle alignment + training, DFA >0.6 acc, eligibility-trace decay, three-factor association, meta-grad + ES reachability.
- Full non-network suite **310 passed**, ruff clean, `ty` clean, `mkdocs build --strict` clean, notebook smoke green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)